### PR TITLE
demo/interactivity router broken

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1089,19 +1089,6 @@ HTML;
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
-			/*
-			 * Initialize the `core/router` store.
-			 * If the store is not initialized like this with minimal
-			 * navigation object, the interactivity-router script module
-			 * errors.
-			 */
-			$this->state(
-				'core/router',
-				array(
-					'navigation' => new stdClass(),
-				)
-			);
-
 			// Enqueues as an inline style.
 			wp_register_style( 'wp-interactivity-router-animations', false );
 			wp_add_inline_style( 'wp-interactivity-router-animations', $this->get_router_animation_styles() );


### PR DESCRIPTION
This demonstrates an error where client side navigation causes an error in the `interactivity-router` package if server side state defining `store.state.navigation` as an object is removed.

Errors:

```
Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'hasStarted')
```

[On this line:](https://github.com/WordPress/gutenberg/blob/67e72757fe37df24a130c17f77064ce3a213722d/packages/interactivity-router/src/index.ts#L295)

```js
// Don't update the navigation status immediately, wait 400 ms.
const loadingTimeout = setTimeout( () => {
if ( navigatingTo !== href ) {
	return;
}

if ( loadingAnimation ) {
	navigation.hasStarted = true; // <---- 💥💥💥 error
	navigation.hasFinished = false;
}
if ( screenReaderAnnouncement ) {
	a11ySpeak( 'loading' );
}
}, 400 );
```


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
