### PR TITLE
With no `e` eval PCRE flag, remove stripslashes

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1818,10 +1818,13 @@ function wp_kses_no_null( $content, $options = null ) {
  *
  * @since 1.0.0
  *
+ * @deprecated 6.9.0 Not necessary since the `e` PCRE modifier was removed in PHP 7.0.
+ *
  * @param string $content String to strip slashes from.
  * @return string Fixed string with quoted slashes.
  */
 function wp_kses_stripslashes( $content ) {
+	_deprecated_function( __FUNCTION__, '6.9.0' );
 	return preg_replace( '%\\\\"%', '"', $content );
 }
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1097,8 +1097,6 @@ function _wp_kses_split_callback( $matches ) {
  * @return string Fixed HTML element
  */
 function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
-	$content = wp_kses_stripslashes( $content );
-
 	/*
 	 * The regex pattern used to split HTML into chunks attempts
 	 * to split on HTML token boundaries. This function should


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

https://wordpress.slack.com/archives/C02RQBWTW/p1755787578111889

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
