### PR TITLE
HTML API: Preserve rawtext contents of IFRAME, NOEMBED, NOFRAMES, and XMP when serializing

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1347,6 +1347,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.7.0
 	 * @since 6.9.0 Converted from protected to public method.
+	 * @since 7.1.0 Contents of IFRAME, NOEMBED, and NOFRAMES elements are
+	 *              serialized literally instead of being dropped.
 	 *
 	 * @return string Serialization of token, or empty string if no serialization exists.
 	 */
@@ -1490,12 +1492,28 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$text = $this->get_modifiable_text();
 
 			switch ( $tag_name ) {
+				/*
+				 * The contents of these elements are emitted literally to preserve
+				 * the document's contents, following the HTML serialization spec:
+				 *
+				 * > If the parent of current node is a style, script, xmp, iframe,
+				 * > noembed, noframes, or plaintext element, or if the parent of
+				 * > current node is a noscript element and scripting is enabled for
+				 * > the node, then append the value of current node's data literally.
+				 *
+				 * This is safe because character references are never decoded in
+				 * their contents. RAWTEXT contents (IFRAME, NOEMBED, NOFRAMES,
+				 * STYLE) cannot contain their own closing tag, so the closer
+				 * appended below cannot be matched early. SCRIPT data may contain
+				 * escaped closers (e.g. within `<!-- -->`), but re-parsing the
+				 * identical bytes follows the same tokenization rules that produced
+				 * this text, terminating at the appended closer all the same.
+				 *
+				 * @see https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments
+				 */
 				case 'IFRAME':
 				case 'NOEMBED':
 				case 'NOFRAMES':
-					$text = '';
-					break;
-
 				case 'SCRIPT':
 				case 'STYLE':
 					break;

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1347,8 +1347,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.7.0
 	 * @since 6.9.0 Converted from protected to public method.
-	 * @since 7.1.0 Contents of IFRAME, NOEMBED, and NOFRAMES elements are
-	 *              serialized literally instead of being dropped.
+	 * @since 7.1.0 Contents of IFRAME, NOEMBED, NOFRAMES, and XMP elements are
+	 *              serialized literally instead of being dropped or escaped.
 	 *
 	 * @return string Serialization of token, or empty string if no serialization exists.
 	 */
@@ -1503,7 +1503,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 *
 				 * This is safe because character references are never decoded in
 				 * their contents. RAWTEXT contents (IFRAME, NOEMBED, NOFRAMES,
-				 * STYLE) cannot contain their own closing tag, so the closer
+				 * STYLE, XMP) cannot contain their own closing tag, so the closer
 				 * appended below cannot be matched early. SCRIPT data may contain
 				 * escaped closers (e.g. within `<!-- -->`), but re-parsing the
 				 * identical bytes follows the same tokenization rules that produced
@@ -1516,8 +1516,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'NOFRAMES':
 				case 'SCRIPT':
 				case 'STYLE':
+				case 'XMP':
 					break;
 
+				/*
+				 * The contents of TEXTAREA and TITLE are parsed as RCDATA, in which
+				 * character references are decoded, so the decoded modifiable text
+				 * must be re-escaped to preserve the document's contents.
+				 */
 				default:
 					$text = htmlspecialchars( $text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8' );
 			}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -135,6 +135,23 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that XMP contents are not escaped, as they are not parsed like text nodes are.
+	 *
+	 * XMP contents are parsed as raw text: character references are never decoded.
+	 * Escaping the contents would change the document, e.g. a "<" would be replaced
+	 * by the literal text "&lt;" after serializing and re-parsing.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_xmp_contents_are_not_escaped() {
+		$this->assertSame(
+			"<xmp>1 < 2 &amp; apples > or\u{FFFD}anges</xmp>",
+			WP_HTML_Processor::normalize( "<xmp>1 < 2 &amp; apples > or\x00anges</xmp>" ),
+			'Should have preserved text inside an XMP element, except for replacing NULL bytes.'
+		);
+	}
+
+	/**
 	 * Ensures that the contents of IFRAME, NOEMBED, and NOFRAMES elements are
 	 * preserved when serializing.
 	 *
@@ -379,6 +396,7 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 			'IFRAME content'       => array( "<iframe>a\x00b</iframe>", "<iframe>a\u{FFFD}b</iframe>" ),
 			'NOEMBED content'      => array( "<noembed>a\x00b</noembed>", "<noembed>a\u{FFFD}b</noembed>" ),
 			'NOFRAMES content'     => array( "<noframes>a\x00b</noframes>", "<noframes>a\u{FFFD}b</noframes>" ),
+			'XMP content'          => array( "<xmp>a\x00b</xmp>", "<xmp>a\u{FFFD}b</xmp>" ),
 			'Comment text'         => array( "<!-- \x00 -->", "<!-- \u{FFFD} -->" ),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -134,6 +134,101 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Ensures that the contents of IFRAME, NOEMBED, and NOFRAMES elements are
+	 * preserved when serializing.
+	 *
+	 * These elements contain raw text which is part of the parsed document.
+	 * Dropping it would change the document's contents across a serialize and
+	 * re-parse cycle.
+	 *
+	 * @ticket 65372
+	 *
+	 * @dataProvider data_rawtext_elements_with_contents
+	 *
+	 * @param string $html Normalized HTML containing a rawtext element with contents.
+	 */
+	public function test_rawtext_element_contents_are_preserved_when_normalizing( string $html ) {
+		$this->assertSame(
+			$html,
+			WP_HTML_Processor::normalize( $html ),
+			'Should have preserved the rawtext element contents.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_rawtext_elements_with_contents() {
+		return array(
+			'IFRAME with following text'       => array( '<iframe>x</iframe>y' ),
+			'NOEMBED with following text'      => array( '<noembed>x</noembed>y' ),
+			'NOFRAMES with following text'     => array( '<section><noframes>x</noframes>y</section>' ),
+			'NOFRAMES before comment'          => array( '<section><noframes>x</noframes><!----></section>' ),
+			'IFRAME with markup-like contents' => array( '<iframe><div>inert</div></iframe>' ),
+			'NOEMBED with character reference' => array( '<noembed>&amp;</noembed>' ),
+			'IFRAME in foreign content'        => array( '<svg><iframe>1 &lt; 2</iframe></svg>' ),
+		);
+	}
+
+	/**
+	 * Ensures that the contents of IFRAME, NOEMBED, and NOFRAMES elements are
+	 * preserved when serializing full documents, including NOFRAMES elements
+	 * in the HEAD or after a FRAMESET.
+	 *
+	 * @ticket 65372
+	 *
+	 * @dataProvider data_full_documents_with_rawtext_elements
+	 *
+	 * @param string $html     Input HTML document.
+	 * @param string $expected Expected serialization of the full document.
+	 */
+	public function test_rawtext_element_contents_are_preserved_in_full_documents( string $html, string $expected ) {
+		$processor = WP_HTML_Processor::create_full_parser( $html );
+
+		$this->assertSame(
+			$expected,
+			$processor->serialize(),
+			'Should have preserved the rawtext element contents.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_full_documents_with_rawtext_elements() {
+		return array(
+			'IFRAME in BODY'          => array(
+				'<iframe>x</iframe>y',
+				'<html><head></head><body><iframe>x</iframe>y</body></html>',
+			),
+			'NOEMBED in BODY'         => array(
+				'a<noembed>x</noembed>',
+				'<html><head></head><body>a<noembed>x</noembed></body></html>',
+			),
+			'NOFRAMES in BODY'        => array(
+				'a<noframes>x</noframes>',
+				'<html><head></head><body>a<noframes>x</noframes></body></html>',
+			),
+			'NOFRAMES in HEAD'        => array(
+				'<head><noframes>x</noframes></head>z',
+				'<html><head><noframes>x</noframes></head><body>z</body></html>',
+			),
+			'NOFRAMES in FRAMESET'    => array(
+				'<html><frameset><noframes>x</noframes>',
+				'<html><head></head><frameset><noframes>x</noframes></frameset></html>',
+			),
+			'IFRAME before a comment' => array(
+				'<h3><div><small><dd><iframe>x</iframe><!---->',
+				'<html><head></head><body><h3><div><small><dd><iframe>x</iframe><!----></dd></small></div></h3></body></html>',
+			),
+		);
+	}
+
 	public function test_unexpected_closing_tags_are_removed() {
 		$this->assertSame(
 			WP_HTML_Processor::normalize( 'one</div>two</span>three' ),
@@ -281,6 +376,9 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 			'Foreign content text' => array( "<svg>one\x00two</svg>", "<svg>one\u{FFFD}two</svg>" ),
 			'SCRIPT content'       => array( "<script>alert(\x00)</script>", "<script>alert(\u{FFFD})</script>" ),
 			'STYLE content'        => array( "<style>\x00 {}</style>", "<style>\u{FFFD} {}</style>" ),
+			'IFRAME content'       => array( "<iframe>a\x00b</iframe>", "<iframe>a\u{FFFD}b</iframe>" ),
+			'NOEMBED content'      => array( "<noembed>a\x00b</noembed>", "<noembed>a\u{FFFD}b</noembed>" ),
+			'NOFRAMES content'     => array( "<noframes>a\x00b</noframes>", "<noframes>a\u{FFFD}b</noframes>" ),
 			'Comment text'         => array( "<!-- \x00 -->", "<!-- \u{FFFD} -->" ),
 		);
 	}


### PR DESCRIPTION
The HTML Processor's serializer destroys the contents of four rawtext elements, so a serialize/re-parse cycle produces a different document than the one parsed:

- **`IFRAME`, `NOEMBED`, `NOFRAMES`**: contents are dropped entirely. `<iframe>x</iframe>y` normalizes to `<iframe></iframe>y`, removing the text node from the tree.
- **`XMP`**: contents are escaped with `htmlspecialchars()`. XMP is rawtext — character references are never decoded on parse — so `<xmp>1 < 2 &amp; more</xmp>` normalizes to `<xmp>1 &lt; 2 &amp;amp; more</xmp>`, which re-parses as the literal text `1 &lt; 2 &amp;amp; more`.

Browsers keep these contents in the DOM and serialize them literally, per the [HTML fragment serialization algorithm](https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments):

> If the parent of current node is a `style`, `script`, `xmp`, `iframe`, `noembed`, `noframes`, or `plaintext` element, or if the parent of current node is a `noscript` element and scripting is enabled for the node, then append the value of current node's data literally.

Compare in a browser:

- [`<iframe>x</iframe>y`](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Ciframe%3Ex%3C%2Fiframe%3Ey) — the text node exists in the parsed tree, and `innerHTML` round-trips it.
- [`<iframe></iframe>y`](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Ciframe%3E%3C%2Fiframe%3Ey) — current serializer output: the text node is gone.
- [`<xmp>1 < 2 &amp; more</xmp>`](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Cxmp%3E1%20%3C%202%20%26amp%3B%20more%3C%2Fxmp%3E) vs. current output [`<xmp>1 &lt; 2 &amp;amp; more</xmp>`](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Cxmp%3E1%20%26lt%3B%202%20%26amp%3Bamp%3B%20more%3C%2Fxmp%3E) — different text contents.
- [`<html><frameset><noframes>x</noframes>`](https://software.hixie.ch/utilities/js/live-dom-viewer/?%3Chtml%3E%3Cframeset%3E%3Cnoframes%3Ex%3C%2Fnoframes%3E) — NOFRAMES contents survive in frameset documents too.

This patch serializes all four literally, joining `SCRIPT` and `STYLE`. Output now matches PHP 8.4's WHATWG-compliant `Dom\HTMLDocument` byte-for-byte on the affected constructs (verified with ~30k differential fuzz inputs; the change fixes every reparse-fidelity failure in that run and introduces no new divergence).

**Why literal emission is safe:**

- Rawtext scanning terminates at the first `</tag` followed by whitespace, `/`, or `>`, so parser-derived contents cannot contain their own closing tag; the appended closer cannot match early. (`SCRIPT` may contain double-escaped closers, but re-parsing identical bytes follows the same tokenization that produced them.)
- Character references are never decoded in these contents (`get_modifiable_text()` returns raw bytes, NUL → U+FFFD), so no re-encoding is needed or correct.
- `set_modifiable_text()` rejects these four elements, so only parser-derived text can ever reach the serializer.

**For reviewers to ratify:** if the blanking was intentional mXSS hardening (these contents are inert in HTML5 browsers but parse as live markup in HTML4-era parsers such as libxml2), this patch reverses it. I believe that hardening was illusory: `SCRIPT`/`STYLE` — strictly more dangerous — always passed through literally, no core code feeds serializer output to a legacy parser, and sanitization is kses's job, not the serializer's. The behavior also contradicted the feature's stated goal of `Dom\HTMLDocument` parity ([r59076]).

Two commits: the dropped-contents fix (`IFRAME`/`NOEMBED`/`NOFRAMES`) and the `XMP` escaping fix.

To test: `vendor/bin/phpunit --filter Tests_HtmlApi_WpHtmlProcessor_Serialize`

Trac ticket: …

Fixes #50 

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Diagnosis, implementation, tests, and differential fuzz verification against `Dom\HTMLDocument`; reviewed and edited by me.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**