### PR TITLE
HTML API: Preserve PRE/LISTING newline skipping after seek

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -754,6 +754,14 @@ class WP_HTML_Tag_Processor {
 	 */
 	protected $bookmarks = array();
 
+	/**
+	 * Tracks bookmarks set on text nodes whose leading linefeed is ignored.
+	 *
+	 * @since 6.9.0
+	 * @var bool[]
+	 */
+	private $bookmarks_with_skipped_newline = array();
+
 	const ADD_CLASS    = true;
 	const REMOVE_CLASS = false;
 	const SKIP_CLASS   = null;
@@ -1357,6 +1365,11 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span( $this->token_starts_at, $this->token_length );
+		if ( self::STATE_TEXT_NODE === $this->parser_state && $this->skip_newline_at === $this->token_starts_at ) {
+			$this->bookmarks_with_skipped_newline[ $name ] = true;
+		} else {
+			unset( $this->bookmarks_with_skipped_newline[ $name ] );
+		}
 
 		return true;
 	}
@@ -1377,6 +1390,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		unset( $this->bookmarks[ $name ] );
+		unset( $this->bookmarks_with_skipped_newline[ $name ] );
 
 		return true;
 	}
@@ -2517,7 +2531,9 @@ class WP_HTML_Tag_Processor {
 			return 0;
 		}
 
-		$accumulated_shift_for_given_point = 0;
+		$accumulated_shift_for_given_point  = 0;
+		$accumulated_shift_for_skip_newline = 0;
+		$skip_newline_at                    = $this->skip_newline_at;
 
 		/*
 		 * Attribute updates can be enqueued in any order but updates
@@ -2541,6 +2557,10 @@ class WP_HTML_Tag_Processor {
 				$this->bytes_already_parsed += $shift;
 			}
 
+			if ( null !== $skip_newline_at && $diff->start < $skip_newline_at ) {
+				$accumulated_shift_for_skip_newline += $shift;
+			}
+
 			// Accumulate shift of the given pointer within this function call.
 			if ( $diff->start < $shift_this_point ) {
 				$accumulated_shift_for_given_point += $shift;
@@ -2549,6 +2569,10 @@ class WP_HTML_Tag_Processor {
 			$output_buffer       .= substr( $this->html, $bytes_already_copied, $diff->start - $bytes_already_copied );
 			$output_buffer       .= $diff->text;
 			$bytes_already_copied = $diff->start + $diff->length;
+		}
+
+		if ( null !== $skip_newline_at ) {
+			$this->skip_newline_at += $accumulated_shift_for_skip_newline;
 		}
 
 		$this->html = $output_buffer . substr( $this->html, $bytes_already_copied );
@@ -2583,8 +2607,11 @@ class WP_HTML_Tag_Processor {
 
 				$delta = strlen( $diff->text ) - $diff->length;
 
-				if ( $bookmark->start >= $diff->start ) {
+				if ( $bookmark->start > $diff->start || ( $bookmark->start === $diff->start && 0 === $diff->length ) ) {
 					$head_delta += $delta;
+					if ( $bookmark->start === $diff->start && 0 === $diff->length && '' !== $diff->text ) {
+						unset( $this->bookmarks_with_skipped_newline[ $bookmark_name ] );
+					}
 				}
 
 				if ( $bookmark_end >= $diff_end ) {
@@ -2657,6 +2684,9 @@ class WP_HTML_Tag_Processor {
 
 		// Point this tag processor before the sought tag opener and consume it.
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
+		$this->skip_newline_at      = isset( $this->bookmarks_with_skipped_newline[ $bookmark_name ] )
+			? $this->bytes_already_parsed
+			: null;
 		$this->parser_state         = self::STATE_READY;
 		return $this->next_token();
 	}
@@ -3635,13 +3665,6 @@ class WP_HTML_Tag_Processor {
 	 * avoid needless crashing or type errors. An empty string does not mean
 	 * that a token has modifiable text, and a token with modifiable text may
 	 * have an empty string (e.g. a comment with no contents).
-	 *
-	 * Limitations:
-	 *
-	 *  - This function will not strip the leading newline appropriately
-	 *    after seeking into a LISTING or PRE element. To ensure that the
-	 *    newline is treated properly, seek to the LISTING or PRE opening
-	 *    tag instead of to the first text node inside the element.
 	 *
 	 * @since 6.5.0
 	 * @since 6.7.0 Replaces NULL bytes (U+0000) and newlines appropriately.

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorModifiableText.php
@@ -10,6 +10,37 @@
  */
 class Tests_HtmlApi_WpHtmlProcessorModifiableText extends WP_UnitTestCase {
 	/**
+	 * Ensures that bookmarked text remains seekable after updating the same text node.
+	 */
+	public function test_seeks_to_bookmarked_text_after_modifiable_text_update(): void {
+		$processor = WP_HTML_Processor::create_fragment( "<pre>\nabc</pre><span>" );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the PRE opener.' );
+		$this->assertSame( 'PRE', $processor->get_token_name(), 'Should have found the PRE opener: check test setup.' );
+
+		while ( $processor->next_token() && 'abc' !== $processor->get_modifiable_text() ) {
+			continue;
+		}
+
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the PRE text node: check test setup.' );
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), 'Should have stripped the leading newline from the PRE text on first traversal.' );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), 'Should have bookmarked the PRE text node.' );
+
+		$this->assertTrue( $processor->set_modifiable_text( 'xyz' ), 'Should have updated the PRE text node.' );
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertSame( 'PRE', $processor->get_token_name(), 'Should have advanced to the PRE closer: check test setup.' );
+		$this->assertSame( "<pre>\nxyz</pre><span>", $processor->get_updated_html(), 'Should have updated the PRE text node.' );
+
+		$this->assertTrue( $processor->seek( 'text' ), 'Should have sought back to the updated PRE text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have sought back to the text node.' );
+		$this->assertSame(
+			'xyz',
+			$processor->get_modifiable_text(),
+			'Should have replayed the updated PRE text node after seeking.'
+		);
+	}
+
+	/**
 	 * TEXTAREA elements ignore the first newline in their content.
 	 * Setting the modifiable text with a leading newline (or carriage return variants)
 	 * should ensure that the leading newline is present in the resulting TEXTAREA.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -411,6 +411,47 @@ HTML;
 	}
 
 	/**
+	 * Ensures that bookmarks stay attached to their original token when text is inserted at the bookmark start.
+	 *
+	 * @ticket 56299
+	 *
+	 * @covers WP_HTML_Tag_Processor::seek
+	 */
+	public function test_updates_bookmark_for_insertions_at_start() {
+		$processor = new class( '<div></div><span></span>' ) extends WP_HTML_Tag_Processor {
+			/**
+			 * Inserts HTML at the start of the given bookmark.
+			 *
+			 * @param string $bookmark_name Bookmark name.
+			 * @param string $html          HTML to insert.
+			 */
+			public function insert_html_at_bookmark_start( string $bookmark_name, string $html ): void {
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->bookmarks[ $bookmark_name ]->start,
+					0,
+					$html
+				);
+			}
+		};
+
+		$processor->next_tag( 'SPAN' );
+		$processor->set_bookmark( 'target' );
+		$processor->insert_html_at_bookmark_start( 'target', '<p></p>' );
+
+		$this->assertSame(
+			'<div></div><p></p><span></span>',
+			$processor->get_updated_html(),
+			'Should have inserted the HTML at the bookmark start.'
+		);
+		$this->assertTrue( $processor->seek( 'target' ), 'Should have sought back to the original bookmarked token.' );
+		$this->assertSame(
+			'SPAN',
+			$processor->get_token_name(),
+			'Should have kept the bookmark attached to the original SPAN token after insertion.'
+		);
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::set_bookmark

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -40,6 +40,261 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that a bookmarked PRE or LISTING text node replays its leading-newline handling after seeking.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_replays_leading_newline_after_seeking_to_text( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$html_tag}>\n \n\n><{$html_tag}>" );
+
+		$this->assertTrue( $processor->next_token(), "Should have found the {$tag_name} opener." );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have found the {$tag_name} opener: check test setup." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the first text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the first text node: check test setup.' );
+
+		$first = $processor->get_modifiable_text();
+		$this->assertSame( " \n\n>", $first, "Should have stripped the leading newline from the {$tag_name} text on first traversal." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have advanced to the next {$tag_name} opener: check test setup." );
+
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the {$tag_name} text node." );
+		$this->assertSame(
+			$first,
+			$processor->get_modifiable_text(),
+			"Should have replayed the leading-newline handling after seeking back to the {$tag_name} text node."
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_token_names_ignoring_leading_newline() {
+		return array(
+			'PRE'     => array( 'PRE' ),
+			'LISTING' => array( 'LISTING' ),
+		);
+	}
+
+	/**
+	 * Ensures that bookmarked text remains seekable after updating the same text node.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_seeks_to_bookmarked_text_after_modifiable_text_update( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$html_tag}>\nabc</{$html_tag}><span>" );
+
+		$this->assertTrue( $processor->next_token(), "Should have found the {$tag_name} opener." );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have found the {$tag_name} opener: check test setup." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the first text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the first text node: check test setup.' );
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should have stripped the leading newline from the {$tag_name} text on first traversal." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$this->assertTrue( $processor->set_modifiable_text( 'xyz' ), "Should have updated the {$tag_name} text node." );
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have advanced to the {$tag_name} closer: check test setup." );
+		$this->assertSame( "<{$html_tag}>xyz</{$html_tag}><span>", $processor->get_updated_html(), "Should have updated the {$tag_name} text node." );
+
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the updated {$tag_name} text node." );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have sought back to the text node.' );
+		$this->assertSame(
+			'xyz',
+			$processor->get_modifiable_text(),
+			"Should have replayed the updated {$tag_name} text node after seeking."
+		);
+	}
+
+	/**
+	 * Ensures that a leading-newline text bookmark can be set after earlier updates are flushed.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_bookmarks_leading_newline_text_after_flushing_prior_update( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<div></div><{$html_tag}>\nabc</{$html_tag}><span>" );
+
+		$this->assertTrue( $processor->next_tag( 'DIV' ), 'Should have found the DIV opener: check test setup.' );
+		$processor->add_class( 'x' );
+
+		while ( $processor->next_token() && '#text' !== $processor->get_token_name() ) {
+			continue;
+		}
+
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should have stripped the leading newline from the {$tag_name} text before flushing updates." );
+		$this->assertSame(
+			"<div class=\"x\"></div><{$html_tag}>\nabc</{$html_tag}><span>",
+			$processor->get_updated_html(),
+			'Should have applied the prior DIV update.'
+		);
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should still strip the leading newline from the {$tag_name} text after flushing updates." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the {$tag_name} text node." );
+		$this->assertSame(
+			'abc',
+			$processor->get_modifiable_text(),
+			"Should have replayed the leading-newline handling after seeking back to the {$tag_name} text node."
+		);
+	}
+
+	/**
+	 * Ensures that skipped-newline state is shifted once when flushing multiple updates.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_bookmarks_leading_newline_text_after_flushing_prior_and_text_updates( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$html_tag}>\nabc</{$html_tag}><span>" );
+
+		$this->assertTrue( $processor->next_token(), "Should have found the {$tag_name} opener." );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have found the {$tag_name} opener: check test setup." );
+		$processor->add_class( 'x' );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the first text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the first text node: check test setup.' );
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should have stripped the leading newline from the {$tag_name} text before flushing updates." );
+		$this->assertTrue( $processor->set_modifiable_text( "\nxy" ), "Should have updated the {$tag_name} text node." );
+
+		$this->assertSame(
+			"<{$html_tag} class=\"x\">\nxy</{$html_tag}><span>",
+			$processor->get_updated_html(),
+			"Should have applied the {$tag_name} opener and text updates."
+		);
+		$this->assertSame( 'xy', $processor->get_modifiable_text(), "Should still strip the leading newline from the updated {$tag_name} text after flushing updates." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the {$tag_name} text node." );
+		$this->assertSame(
+			'xy',
+			$processor->get_modifiable_text(),
+			"Should have replayed the leading-newline handling after seeking back to the updated {$tag_name} text node."
+		);
+	}
+
+	/**
+	 * Ensures that inserted markup at the bookmarked text start cancels leading-newline handling.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_bookmarked_leading_newline_text_after_insertion_at_start( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new class( "<{$html_tag}>\nabc</{$html_tag}><span>" ) extends WP_HTML_Tag_Processor {
+			/**
+			 * Inserts HTML at the start of the given bookmark.
+			 *
+			 * @param string $bookmark_name Bookmark name.
+			 * @param string $html          HTML to insert.
+			 */
+			public function insert_html_at_bookmark_start( string $bookmark_name, string $html ): void {
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->bookmarks[ $bookmark_name ]->start,
+					0,
+					$html
+				);
+			}
+		};
+
+		$this->assertTrue( $processor->next_token(), "Should have found the {$tag_name} opener." );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have found the {$tag_name} opener: check test setup." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the first text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the first text node: check test setup.' );
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should have stripped the leading newline from the {$tag_name} text on first traversal." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$processor->insert_html_at_bookmark_start( 'text', '<b></b>' );
+		$this->assertSame(
+			"<{$html_tag}><b></b>\nabc</{$html_tag}><span>",
+			$processor->get_updated_html(),
+			"Should have inserted markup at the start of the {$tag_name} text node."
+		);
+
+		while ( $processor->next_token() && '#text' !== $processor->get_token_name() ) {
+			continue;
+		}
+
+		$normal_scan_text = $processor->get_modifiable_text();
+		$this->assertSame( "\nabc", $normal_scan_text, "Should not strip the newline after inserting markup before the {$tag_name} text." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the {$tag_name} text node." );
+		$this->assertSame(
+			$normal_scan_text,
+			$processor->get_modifiable_text(),
+			"Should have replayed the same {$tag_name} text after seeking."
+		);
+	}
+
+	/**
+	 * Ensures that a no-op update at the bookmarked text start preserves leading-newline handling.
+	 *
+	 * @dataProvider data_token_names_ignoring_leading_newline
+	 *
+	 * @param string $tag_name Tag name whose first text node ignores a leading newline.
+	 */
+	public function test_bookmarked_leading_newline_text_after_noop_at_start( string $tag_name ) {
+		$html_tag  = strtolower( $tag_name );
+		$processor = new class( "<{$html_tag}>\nabc</{$html_tag}><span>" ) extends WP_HTML_Tag_Processor {
+			/**
+			 * Enqueues a no-op update at the start of the given bookmark.
+			 *
+			 * @param string $bookmark_name Bookmark name.
+			 */
+			public function enqueue_noop_at_bookmark_start( string $bookmark_name ): void {
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->bookmarks[ $bookmark_name ]->start,
+					0,
+					''
+				);
+			}
+		};
+
+		$this->assertTrue( $processor->next_token(), "Should have found the {$tag_name} opener." );
+		$this->assertSame( $tag_name, $processor->get_token_name(), "Should have found the {$tag_name} opener: check test setup." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the first text node.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Should have found the first text node: check test setup.' );
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should have stripped the leading newline from the {$tag_name} text on first traversal." );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), "Should have bookmarked the {$tag_name} text node." );
+
+		$processor->enqueue_noop_at_bookmark_start( 'text' );
+		$this->assertSame(
+			"<{$html_tag}>\nabc</{$html_tag}><span>",
+			$processor->get_updated_html(),
+			'Should not have changed the HTML.'
+		);
+		$this->assertSame( 'abc', $processor->get_modifiable_text(), "Should still strip the leading newline from the {$tag_name} text after the no-op update." );
+
+		$this->assertTrue( $processor->next_token(), 'Should have advanced away from the bookmarked text node.' );
+		$this->assertTrue( $processor->seek( 'text' ), "Should have sought back to the {$tag_name} text node." );
+		$this->assertSame(
+			'abc',
+			$processor->get_modifiable_text(),
+			"Should have replayed the leading-newline handling after seeking back to the {$tag_name} text node."
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]
@@ -324,14 +579,10 @@ HTML
 		);
 
 		$processor->seek( 'listing' );
-		if ( "\ngone" === $processor->get_modifiable_text() ) {
-			$this->markTestSkipped( "There's no support currently for handling the leading newline after seeking." );
-		}
-
 		$this->assertSame(
 			'gone',
 			$processor->get_modifiable_text(),
-			'Should have remembered to remote leading newline from LISTING element after seeking around it.'
+			'Should have remembered to remove the leading newline from LISTING element after seeking around it.'
 		);
 
 		$processor->seek( 'div' );


### PR DESCRIPTION
## Summary

- Preserve PRE/LISTING skipped-newline state when seeking back to a bookmarked text token.
- Restore skipped-newline state during `seek()` and keep it aligned when pending updates shift token offsets.
- Add bookmark and modifiable-text regressions for affected update and seek paths.

## Testing

- HTML API and html5lib PHPUnit groups pass.
- PHPCS, syntax checks, and whitespace checks pass.
- `codex review --base trunk`.

Trac ticket: https://core.trac.wordpress.org/ticket/65372

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Diagnosing the seek replay bug, test iteration, PR description cleanup, and code review.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
