### PR TITLE
HTML API: Ignore leading newline after seeking to text following PRE

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -827,6 +827,23 @@ class WP_HTML_Tag_Processor {
 	private $skip_newline_at = null;
 
 	/**
+	 * Indicates which bookmarks point to a token which immediately follows
+	 * the opening tag of a LISTING or PRE element, where a leading newline
+	 * should be ignored when reading modifiable text.
+	 *
+	 * When seeking to a bookmark, this state must be restored because it
+	 * cannot be re-derived from the bookmarked location alone.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @see WP_HTML_Tag_Processor::$skip_newline_at
+	 * @see WP_HTML_Tag_Processor::seek()
+	 *
+	 * @var array<string, true>
+	 */
+	private $bookmark_skips_newline = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 6.2.0
@@ -1358,6 +1375,12 @@ class WP_HTML_Tag_Processor {
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span( $this->token_starts_at, $this->token_length );
 
+		if ( $this->token_starts_at === $this->skip_newline_at ) {
+			$this->bookmark_skips_newline[ $name ] = true;
+		} else {
+			unset( $this->bookmark_skips_newline[ $name ] );
+		}
+
 		return true;
 	}
 
@@ -1376,7 +1399,7 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		unset( $this->bookmarks[ $name ] );
+		unset( $this->bookmarks[ $name ], $this->bookmark_skips_newline[ $name ] );
 
 		return true;
 	}
@@ -2620,6 +2643,7 @@ class WP_HTML_Tag_Processor {
 	 * maximum limit on the number of times seek() can be called.
 	 *
 	 * @since 6.2.0
+	 * @since 7.1.0 Restores the ignored-newline state for tokens following LISTING and PRE opening tags.
 	 *
 	 * @param string $bookmark_name Jump to the place in the document identified by this bookmark name.
 	 * @return bool Whether the internal cursor was successfully moved to the bookmark's location.
@@ -2658,6 +2682,18 @@ class WP_HTML_Tag_Processor {
 		// Point this tag processor before the sought tag opener and consume it.
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
 		$this->parser_state         = self::STATE_READY;
+
+		/*
+		 * The leading newline after a LISTING or PRE opening tag is ignored
+		 * as an authoring convenience. This state is set when scanning past
+		 * one of these opening tags, but a later LISTING or PRE tag may have
+		 * overwritten it; it must be restored from the bookmark when seeking
+		 * to a token which immediately follows such an opening tag.
+		 */
+		$this->skip_newline_at = isset( $this->bookmark_skips_newline[ $bookmark_name ] )
+			? $this->bytes_already_parsed
+			: null;
+
 		return $this->next_token();
 	}
 
@@ -3642,15 +3678,9 @@ class WP_HTML_Tag_Processor {
 	 * that a token has modifiable text, and a token with modifiable text may
 	 * have an empty string (e.g. a comment with no contents).
 	 *
-	 * Limitations:
-	 *
-	 *  - This function will not strip the leading newline appropriately
-	 *    after seeking into a LISTING or PRE element. To ensure that the
-	 *    newline is treated properly, seek to the LISTING or PRE opening
-	 *    tag instead of to the first text node inside the element.
-	 *
 	 * @since 6.5.0
 	 * @since 6.7.0 Replaces NULL bytes (U+0000) and newlines appropriately.
+	 * @since 7.1.0 Ignores the leading newline after LISTING and PRE opening tags even after seeking.
 	 *
 	 * @return string
 	 */

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2530,6 +2530,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @since 6.2.1 Accumulates shift for internal cursor and passed pointer.
 	 * @since 6.3.0 Invalidate any bookmarks whose targets are overwritten.
+	 * @since 7.1.0 Accumulates shift for the ignored-newline position after LISTING and PRE opening tags.
 	 * @ignore
 	 *
 	 * @param int $shift_this_point Accumulate and return shift for this position.
@@ -2540,7 +2541,8 @@ class WP_HTML_Tag_Processor {
 			return 0;
 		}
 
-		$accumulated_shift_for_given_point = 0;
+		$accumulated_shift_for_given_point  = 0;
+		$accumulated_shift_for_skip_newline = 0;
 
 		/*
 		 * Attribute updates can be enqueued in any order but updates
@@ -2564,6 +2566,11 @@ class WP_HTML_Tag_Processor {
 				$this->bytes_already_parsed += $shift;
 			}
 
+			// Accumulate shift of the ignored-newline position within this function call.
+			if ( null !== $this->skip_newline_at && $diff->start < $this->skip_newline_at ) {
+				$accumulated_shift_for_skip_newline += $shift;
+			}
+
 			// Accumulate shift of the given pointer within this function call.
 			if ( $diff->start < $shift_this_point ) {
 				$accumulated_shift_for_given_point += $shift;
@@ -2575,6 +2582,11 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->html = $output_buffer . substr( $this->html, $bytes_already_copied );
+
+		// Adjust the ignored-newline position by however much the updates moved it.
+		if ( null !== $this->skip_newline_at ) {
+			$this->skip_newline_at += $accumulated_shift_for_skip_newline;
+		}
 
 		/*
 		 * Adjust bookmark locations to account for how the text
@@ -3680,7 +3692,8 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.5.0
 	 * @since 6.7.0 Replaces NULL bytes (U+0000) and newlines appropriately.
-	 * @since 7.1.0 Ignores the leading newline after LISTING and PRE opening tags even after seeking.
+	 * @since 7.1.0 Ignores the leading newline after LISTING and PRE opening tags even after
+	 *              seeking or applying enqueued updates.
 	 *
 	 * @return string
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -275,6 +275,8 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	/**
 	 * Ensures that when ignoring a newline after LISTING and PRE tags, that this
 	 * happens appropriately after seeking.
+	 *
+	 * @ticket 65372
 	 */
 	public function test_get_modifiable_text_ignores_newlines_after_seeking() {
 		$processor = new WP_HTML_Tag_Processor(
@@ -324,14 +326,10 @@ HTML
 		);
 
 		$processor->seek( 'listing' );
-		if ( "\ngone" === $processor->get_modifiable_text() ) {
-			$this->markTestSkipped( "There's no support currently for handling the leading newline after seeking." );
-		}
-
 		$this->assertSame(
 			'gone',
 			$processor->get_modifiable_text(),
-			'Should have remembered to remote leading newline from LISTING element after seeking around it.'
+			'Should have remembered to remove the leading newline from LISTING element after seeking around it.'
 		);
 
 		$processor->seek( 'div' );
@@ -340,6 +338,89 @@ HTML
 			$processor->get_modifiable_text(),
 			'Should not have removed the leading newline from the last DIV on its second traversal.'
 		);
+	}
+
+	/**
+	 * Ensures that seeking directly to a text node immediately following a PRE
+	 * or LISTING opener continues to ignore its leading newline, even after
+	 * passing another PRE or LISTING tag before seeking.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::seek
+	 * @covers WP_HTML_Tag_Processor::get_modifiable_text
+	 *
+	 * @dataProvider data_pre_and_listing_tags
+	 *
+	 * @param string $tag_name Tag name of the element which ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_ignores_leading_newline_after_seeking_directly_to_text( string $tag_name ) {
+		$tag       = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$tag}>\n \n\n><{$tag}>" );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the first tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the first tag: check test setup.' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the text node: check test setup.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Failed to find the text node: check test setup.' );
+
+		$before_seeking = $processor->get_modifiable_text();
+		$this->assertSame( " \n\n>", $before_seeking, 'Should have ignored the leading newline on the first traversal.' );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), 'Failed to set a bookmark on the text node: check test setup.' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the second tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the second tag: check test setup.' );
+
+		$this->assertTrue( $processor->seek( 'text' ), 'Failed to seek to the bookmarked text node.' );
+		$this->assertSame( $before_seeking, $processor->get_modifiable_text(), 'Should have ignored the leading newline after seeking back to the text node.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_pre_and_listing_tags() {
+		return array(
+			'PRE'     => array( 'PRE' ),
+			'LISTING' => array( 'LISTING' ),
+		);
+	}
+
+	/**
+	 * Ensures that seeking directly to a text node immediately following a PRE
+	 * or LISTING opener continues to ignore its leading newline when document
+	 * offsets have shifted from applying enqueued attribute updates.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::seek
+	 * @covers WP_HTML_Tag_Processor::get_modifiable_text
+	 *
+	 * @dataProvider data_pre_and_listing_tags
+	 *
+	 * @param string $tag_name Tag name of the element which ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_ignores_leading_newline_after_seeking_when_offsets_have_shifted( string $tag_name ) {
+		$tag       = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$tag} class=\"pad\">\nfoo<{$tag}>" );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the first tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the first tag: check test setup.' );
+		$processor->remove_attribute( 'class' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the text node: check test setup.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Failed to find the text node: check test setup.' );
+
+		$before_seeking = $processor->get_modifiable_text();
+		$this->assertSame( 'foo', $before_seeking, 'Should have ignored the leading newline on the first traversal.' );
+		$this->assertTrue( $processor->set_bookmark( 'text' ), 'Failed to set a bookmark on the text node: check test setup.' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the second tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the second tag: check test setup.' );
+
+		$this->assertTrue( $processor->seek( 'text' ), 'Failed to seek to the bookmarked text node.' );
+		$this->assertSame( $before_seeking, $processor->get_modifiable_text(), 'Should have ignored the leading newline after seeking back to the text node.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -388,6 +388,106 @@ HTML
 	}
 
 	/**
+	 * Ensures that reading the text node immediately following a PRE or
+	 * LISTING opener continues to ignore its leading newline after enqueued
+	 * updates have been applied and document offsets have shifted.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::get_updated_html
+	 * @covers WP_HTML_Tag_Processor::get_modifiable_text
+	 *
+	 * @dataProvider data_pre_and_listing_tags
+	 *
+	 * @param string $tag_name Tag name of the element which ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_ignores_leading_newline_after_applying_updates( string $tag_name ) {
+		$tag       = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$tag} class=\"pad\">\nfoo" );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the tag: check test setup.' );
+		$processor->remove_attribute( 'class' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the text node: check test setup.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Failed to find the text node: check test setup.' );
+
+		$before_applying = $processor->get_modifiable_text();
+		$this->assertSame( 'foo', $before_applying, 'Should have ignored the leading newline before applying updates.' );
+
+		$processor->get_updated_html();
+		$this->assertSame( $before_applying, $processor->get_modifiable_text(), 'Should have ignored the leading newline after applying updates.' );
+	}
+
+	/**
+	 * Ensures that reading the text node immediately following a PRE or
+	 * LISTING opener continues to ignore its leading newline after applying
+	 * multiple enqueued updates of different sizes in a single pass.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::get_updated_html
+	 * @covers WP_HTML_Tag_Processor::get_modifiable_text
+	 *
+	 * @dataProvider data_pre_and_listing_tags
+	 *
+	 * @param string $tag_name Tag name of the element which ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_ignores_leading_newline_after_applying_multiple_updates( string $tag_name ) {
+		$tag       = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<div class=\"aaaaaaaaaaaaaaaaaaaa\">x</div><{$tag} aaaaaaaaaaaaaaaaaaaaaaaa=\"x\" b=\"y\">\nfoo" );
+
+		$this->assertTrue( $processor->next_tag( 'DIV' ), 'Failed to find the DIV: check test setup.' );
+		$processor->remove_attribute( 'class' );
+
+		$this->assertTrue( $processor->next_tag( $tag_name ), 'Failed to find the tag: check test setup.' );
+		$processor->remove_attribute( 'aaaaaaaaaaaaaaaaaaaaaaaa' );
+		$processor->remove_attribute( 'b' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the text node: check test setup.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Failed to find the text node: check test setup.' );
+
+		$before_applying = $processor->get_modifiable_text();
+		$this->assertSame( 'foo', $before_applying, 'Should have ignored the leading newline before applying updates.' );
+
+		$processor->get_updated_html();
+		$this->assertSame( $before_applying, $processor->get_modifiable_text(), 'Should have ignored the leading newline after applying updates.' );
+	}
+
+	/**
+	 * Ensures that the text node immediately following a PRE or LISTING opener
+	 * continues to ignore its leading newline after applying an attribute
+	 * update on the opener together with a replacement of the text itself.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers WP_HTML_Tag_Processor::get_updated_html
+	 * @covers WP_HTML_Tag_Processor::get_modifiable_text
+	 *
+	 * @dataProvider data_pre_and_listing_tags
+	 *
+	 * @param string $tag_name Tag name of the element which ignores a leading newline.
+	 */
+	public function test_get_modifiable_text_ignores_leading_newline_after_growing_opener_and_replacing_text( string $tag_name ) {
+		$tag       = strtolower( $tag_name );
+		$processor = new WP_HTML_Tag_Processor( "<{$tag}>\nfoo" );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the tag: check test setup.' );
+		$this->assertSame( $tag_name, $processor->get_token_name(), 'Failed to find the tag: check test setup.' );
+		$processor->set_attribute( 'class', 'wide' );
+
+		$this->assertTrue( $processor->next_token(), 'Failed to find the text node: check test setup.' );
+		$this->assertSame( '#text', $processor->get_token_name(), 'Failed to find the text node: check test setup.' );
+		$this->assertTrue( $processor->set_modifiable_text( "\nlonger" ), 'Failed to replace the modifiable text: check test setup.' );
+
+		$before_applying = $processor->get_modifiable_text();
+		$this->assertSame( 'longer', $before_applying, 'Should have ignored the leading newline before applying updates.' );
+
+		$processor->get_updated_html();
+		$this->assertSame( $before_applying, $processor->get_modifiable_text(), 'Should have ignored the leading newline after applying updates.' );
+	}
+
+	/**
 	 * Ensures that seeking directly to a text node immediately following a PRE
 	 * or LISTING opener continues to ignore its leading newline when document
 	 * offsets have shifted from applying enqueued attribute updates.


### PR DESCRIPTION
## Summary

- Preserve ignored-newline state when seeking back to text immediately after `PRE` or `LISTING`.
- Shift `skip_newline_at` when queued updates move the affected text token.
- Keep normal text, `TEXTAREA`, and opener-seek behavior unchanged.

## Testing

- HTML API and html5lib PHPUnit groups pass, including new PRE/LISTING seek regressions.
- PHPCS pass for the changed HTML API files.
- `codex review --base trunk`.

Trac ticket: https://core.trac.wordpress.org/ticket/65372

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: PR description cleanup and code review.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
