### PR TITLE
Docs: Clarify when to use the HTML Processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -24,6 +24,17 @@
 /**
  * Core class used to modify attributes in an HTML document for tags matching a query.
  *
+ * The Tag Processor scans an HTML document linearly and is designed for
+ * position-based work on individual tags: finding tags by name or class,
+ * reading and changing attributes, and preserving the rest of the input
+ * byte-for-byte.
+ *
+ * It does not track the parsed document tree. It provides no nesting depth,
+ * ancestor breadcrumbs, or guarantee that every opener is paired with a closer.
+ * Use {@see WP_HTML_Processor} when structure matters, such as checking whether
+ * one element is inside another, walking a subtree, collecting an element's text
+ * content, or working with implied closing tags the way a browser parser would.
+ *
  * ## Usage
  *
  * Use of this class requires three steps:


### PR DESCRIPTION
## Summary
- Clarifies that the Tag Processor is a linear, position-based tag and attribute tool.
- Points structural work, such as subtree walks, ancestor checks, and implied closing tags, to `WP_HTML_Processor`.

## Why this matters
This helps developers start with the correct API boundary: use the Tag Processor for linear tag and attribute edits, and use the HTML Processor when the task depends on document structure, ancestors, subtree boundaries, or implied closing tags.

## Verification
- `php -l src/wp-includes/html-api/class-wp-html-tag-processor.php`
- `git diff --check`

Trac ticket: TBD

## Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Used for: Reviewing the generated documentation-improvement branch, splitting evidence-backed changes into focused PRs, drafting wording, and running local verification. Final changes were reviewed against source behavior and experiment notes.
