### PR TITLE
Add set_inner_html to WP_HTML_Processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1524,6 +1524,398 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Replaces the inner HTML of the currently-matched element, if possible.
+	 *
+	 * The processor must be paused on the opening tag of an element which can
+	 * contain content: it cannot be paused on a void element (e.g. an IMG
+	 * element), on a self-contained element whose contents require a special
+	 * tokenizer state (e.g. a SCRIPT or TEXTAREA element), or on any token
+	 * which does not appear in the input HTML text (e.g. a TBODY element
+	 * implied by a TR inside a TABLE).
+	 *
+	 * Unlike the DOM `innerHTML` setter, which operates on a tree, this method
+	 * operates on the HTML text of the document. There are trees which can be
+	 * created through the DOM whose HTML serialization does not reproduce the
+	 * same tree. Content is rejected unless the final document parses with the
+	 * new content fully contained inside the context element and with no
+	 * changes of any kind outside of it.
+	 *
+	 * Rejected content leaves the document unmodified and returns `false`:
+	 *
+	 *  - Content which would close the context element or continue outside of it,
+	 *    e.g. setting `</p>outside` inside a P element.
+	 *  - Content whose elements would implicitly close the context element,
+	 *    e.g. setting `<li>` inside an LI element, or `<a>` inside an A element,
+	 *    because nesting these elements cannot be represented in HTML text.
+	 *  - Content which would modify parts of the document following the context
+	 *    element, e.g. setting `<b>unclosed` inside a DIV element which is
+	 *    followed by more content, because the unclosed B element would wrap
+	 *    that following content when the document is parsed again.
+	 *  - Content which the HTML Processor cannot parse, e.g. markup requiring
+	 *    foster-parenting, such as setting `text` directly inside a TABLE element.
+	 *  - Content inside a SELECT element other than OPTION, OPTGROUP, and HR
+	 *    elements, text, and comments, because the parsing rules for SELECT
+	 *    elements have recently changed in HTML and differ across parsers.
+	 *
+	 * Example:
+	 *
+	 *     $processor = WP_HTML_Processor::create_fragment( '<div>old</div><p>kept</p>' );
+	 *     $processor->next_tag( 'DIV' );
+	 *     true === $processor->set_inner_html( '<p>one<p>two' );
+	 *     $processor->get_updated_html() === '<div><p>one<p>two</div><p>kept</p>';
+	 *
+	 *     $processor = WP_HTML_Processor::create_fragment( '<a href="/wp/">WordPress</a>' );
+	 *     $processor->next_tag( 'A' );
+	 *     false === $processor->set_inner_html( '<a>links cannot nest</a>' );
+	 *     $processor->get_updated_html() === '<a href="/wp/">WordPress</a>';
+	 *
+	 * After a successful replacement the processor remains paused on the opening
+	 * tag of the context element; proceeding onward parses the new content.
+	 * Bookmarks pointing to tokens within the replaced content are released.
+	 *
+	 * Verification requires reparsing the document from its beginning both with
+	 * and without the replacement; this is an expensive operation which should
+	 * not be repeated in tight loops.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $html Raw HTML to replace the contents of the currently-matched element.
+	 * @return bool Whether the content was accepted and the document updated.
+	 */
+	public function set_inner_html( string $html ): bool {
+		if ( null !== $this->last_error ) {
+			return false;
+		}
+
+		/*
+		 * The processor must be paused on the opening tag of an element
+		 * found in the input HTML text which expects a closing tag.
+		 */
+		if (
+			null === $this->current_element ||
+			'#tag' !== $this->get_token_type() ||
+			$this->is_tag_closer() ||
+			$this->is_virtual() ||
+			true !== $this->expects_closer() ||
+			! isset( $this->bookmarks[ $this->current_element->token->bookmark_name ] )
+		) {
+			return false;
+		}
+
+		// Only fragment parsers with a BODY context can be reproduced for verification.
+		if ( null !== $this->context_node && 'BODY' !== $this->context_node->node_name ) {
+			return false;
+		}
+
+		/*
+		 * Reject content whose parsing is known to diverge from browsers,
+		 * because reparsing with the HTML Processor cannot detect whether
+		 * such content modifies the document outside of the context element.
+		 *
+		 *  - When an HTML or BODY start tag appears in a document, HTML parsers
+		 *    may adopt its attributes onto the existing HTML or BODY elements,
+		 *    modifying elements outside of the context element. The HTML
+		 *    Processor ignores these tags instead of adopting the attributes.
+		 *
+		 *  - The HTML Processor still parses SELECT content under rules which
+		 *    predate the "customizable select element" changes to HTML. It
+		 *    ignores most tags inside a SELECT element, while up-to-date
+		 *    parsers allow many of them, possibly escaping the SELECT and
+		 *    reopening formatting elements beyond the context element. Only
+		 *    tokens treated identically under both revisions of HTML are
+		 *    allowed inside a SELECT element. See https://core.trac.wordpress.org/ticket/63736.
+		 */
+		$context_in_select = in_array( 'SELECT', $this->get_breadcrumbs(), true );
+		$select_depth      = $context_in_select ? 1 : 0;
+
+		$scan = new WP_HTML_Tag_Processor( $html );
+		while ( $scan->next_token() ) {
+			if ( '#tag' !== $scan->get_token_type() ) {
+				continue;
+			}
+
+			$scanned_tag = $scan->get_token_name();
+
+			if ( $scan->is_tag_closer() ) {
+				if ( 'SELECT' === $scanned_tag ) {
+					// A SELECT containing the context element may not be closed.
+					if ( $context_in_select ) {
+						return false;
+					}
+					if ( $select_depth > 0 ) {
+						--$select_depth;
+					}
+				} elseif (
+					$select_depth > 0 &&
+					! in_array( $scanned_tag, array( 'OPTION', 'OPTGROUP', 'HR' ), true )
+				) {
+					return false;
+				}
+				continue;
+			}
+
+			if ( 'HTML' === $scanned_tag || 'BODY' === $scanned_tag ) {
+				return false;
+			}
+
+			if ( 'SELECT' === $scanned_tag ) {
+				// A SELECT element may not appear inside another SELECT element.
+				if ( $select_depth > 0 ) {
+					return false;
+				}
+				++$select_depth;
+				continue;
+			}
+
+			if (
+				$select_depth > 0 &&
+				! in_array( $scanned_tag, array( 'OPTION', 'OPTGROUP', 'HR' ), true )
+			) {
+				return false;
+			}
+		}
+
+		// Apply any pending updates so that the document below is final.
+		$this->get_updated_html();
+
+		$document      = $this->html;
+		$context_token = $this->current_element->token;
+		$context_span  = $this->bookmarks[ $context_token->bookmark_name ];
+		$inner_start   = $context_span->start + $context_span->length;
+
+		/*
+		 * Walk a parser over the existing document to find where the context
+		 * element closes, and record every stack operation which occurs from
+		 * that closing through the end of the document. These operations
+		 * describe the structure of the document outside (after) the context
+		 * element, which the new content must leave fully unmodified.
+		 */
+		$original = $this->create_equivalent_parser( $document );
+		if (
+			null === $original ||
+			! self::advance_to_tag_opener_at( $original, $context_span->start, $context_token->node_name )
+		) {
+			return false;
+		}
+
+		$original_context = $original->current_element->token;
+		$found_closing    = false;
+		while ( $original->next_token() ) {
+			$event = $original->current_element;
+			if ( WP_HTML_Stack_Event::POP === $event->operation && $event->token === $original_context ) {
+				$found_closing = true;
+				break;
+			}
+		}
+
+		if ( ! $found_closing ) {
+			// The document could not be fully parsed: unable to verify the replacement.
+			return false;
+		}
+
+		/*
+		 * The inner content ends where the token responsible for closing the
+		 * context element begins: at its closing tag when explicitly closed,
+		 * at the token which implicitly closed it, or at the end of the
+		 * document when no content closed it.
+		 */
+		$at_end_of_document = (
+			WP_HTML_Tag_Processor::STATE_COMPLETE === $original->parser_state ||
+			WP_HTML_Tag_Processor::STATE_INCOMPLETE_INPUT === $original->parser_state ||
+			null === $original->state->current_token
+		);
+
+		$inner_end = $at_end_of_document
+			? strlen( $document )
+			: $original->bookmarks[ $original->state->current_token->bookmark_name ]->start;
+
+		$expected_events = array( self::stack_event_signature( $original, $inner_end ) );
+		while ( $original->next_token() ) {
+			$expected_events[] = self::stack_event_signature( $original, $inner_end );
+		}
+
+		if ( null !== $original->get_last_error() ) {
+			return false;
+		}
+
+		/*
+		 * Reparse the document with the new content in place. The new content
+		 * must remain fully contained within the context element, and from the
+		 * closing of the context element onward, the document must produce
+		 * exactly the same structure as it did without the replacement.
+		 */
+		$candidate_document = substr( $document, 0, $inner_start ) . $html . substr( $document, $inner_end );
+		$candidate_end      = $inner_start + strlen( $html );
+
+		$candidate = $this->create_equivalent_parser( $candidate_document );
+		if (
+			null === $candidate ||
+			! self::advance_to_tag_opener_at( $candidate, $context_span->start, $context_token->node_name )
+		) {
+			return false;
+		}
+
+		$candidate_context = $candidate->current_element->token;
+		$context_depth     = $candidate->get_current_depth();
+		$opened_by_content = array();
+		$found_closing     = false;
+		while ( $candidate->next_token() ) {
+			$event = $candidate->current_element;
+
+			if ( WP_HTML_Stack_Event::POP === $event->operation ) {
+				if ( $event->token === $candidate_context ) {
+					$found_closing = true;
+					break;
+				}
+
+				// Only elements opened by the new content may be closed by it.
+				if ( ! isset( $opened_by_content[ spl_object_id( $event->token ) ] ) ) {
+					return false;
+				}
+			} else {
+				// Every element opened before the context element closes must be inside of it.
+				if ( $candidate->get_current_depth() <= $context_depth ) {
+					return false;
+				}
+				$opened_by_content[ spl_object_id( $event->token ) ] = true;
+			}
+		}
+
+		if ( ! $found_closing ) {
+			return false;
+		}
+
+		$expected_count = count( $expected_events );
+		$expected_index = 0;
+		if ( self::stack_event_signature( $candidate, $candidate_end ) !== $expected_events[ $expected_index++ ] ) {
+			return false;
+		}
+
+		while ( $candidate->next_token() ) {
+			if (
+				$expected_index >= $expected_count ||
+				self::stack_event_signature( $candidate, $candidate_end ) !== $expected_events[ $expected_index++ ]
+			) {
+				return false;
+			}
+		}
+
+		if ( $expected_index !== $expected_count || null !== $candidate->get_last_error() ) {
+			return false;
+		}
+
+		/*
+		 * The replacement is proven safe: apply it to the document.
+		 *
+		 * Bookmarks pointing into the replaced content refer to tokens
+		 * which no longer exist and must be released.
+		 */
+		foreach ( $this->bookmarks as $bookmark_name => $bookmark_span ) {
+			if (
+				$bookmark_span->start < $inner_end &&
+				$bookmark_span->start + $bookmark_span->length > $inner_start
+			) {
+				unset( $this->bookmarks[ $bookmark_name ] );
+			}
+		}
+
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $inner_start, $inner_end - $inner_start, $html );
+		$this->get_updated_html();
+
+		return true;
+	}
+
+	/**
+	 * Creates a new HTML Processor over the given document, constructed in
+	 * the same parsing mode as this processor, for verifying modifications.
+	 *
+	 * The base class is used intentionally so that verification follows
+	 * core HTML semantics even when called from a subclass.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $document Full text of the document to parse.
+	 * @return WP_HTML_Processor|null The created processor if successful, otherwise null.
+	 */
+	private function create_equivalent_parser( string $document ): ?WP_HTML_Processor {
+		return null === $this->context_node
+			? WP_HTML_Processor::create_full_parser( $document )
+			: WP_HTML_Processor::create_fragment( $document );
+	}
+
+	/**
+	 * Advances a processor to the opening tag found at the given byte offset
+	 * in its document.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_HTML_Processor $walker    Processor to advance.
+	 * @param int               $at        Byte offset into the document where the opening tag starts.
+	 * @param string            $node_name Node name the found tag must have.
+	 * @return bool Whether the processor was paused on the described opening tag.
+	 */
+	private static function advance_to_tag_opener_at( WP_HTML_Processor $walker, int $at, string $node_name ): bool {
+		while ( $walker->next_token() ) {
+			$event = $walker->current_element;
+			if (
+				WP_HTML_Stack_Event::PUSH === $event->operation &&
+				'real' === $event->provenance &&
+				isset( $walker->bookmarks[ $event->token->bookmark_name ] ) &&
+				$walker->bookmarks[ $event->token->bookmark_name ]->start === $at
+			) {
+				return $event->token->node_name === $node_name;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Describes the stack operation a processor is currently paused on, in a
+	 * form which can be compared across two parses of related documents.
+	 *
+	 * The signature contains the operation, the node it operates on, where in
+	 * the document it occurred (relative to the given base offset), and the
+	 * resulting path from the root of the document. Two matching parses
+	 * produce equal signature sequences; any structural divergence produces
+	 * a differing signature.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_HTML_Processor $walker      Processor paused on a stack event.
+	 * @param int               $base_offset Byte offset from which event locations are measured.
+	 * @return array Comparable description of the stack event.
+	 */
+	private static function stack_event_signature( WP_HTML_Processor $walker, int $base_offset ): array {
+		$at_end_of_document = (
+			WP_HTML_Tag_Processor::STATE_COMPLETE === $walker->parser_state ||
+			WP_HTML_Tag_Processor::STATE_INCOMPLETE_INPUT === $walker->parser_state ||
+			null === $walker->state->current_token
+		);
+
+		if ( $at_end_of_document ) {
+			$at     = 'end-of-document';
+			$length = 0;
+		} else {
+			$span   = $walker->bookmarks[ $walker->state->current_token->bookmark_name ];
+			$at     = $span->start - $base_offset;
+			$length = $span->length;
+		}
+
+		$event = $walker->current_element;
+
+		return array(
+			'operation'  => $event->operation,
+			'provenance' => $event->provenance,
+			'node_name'  => $event->token->node_name,
+			'namespace'  => $event->token->namespace,
+			'at'         => $at,
+			'length'     => $length,
+			'path'       => implode( ' > ', $walker->get_breadcrumbs() ),
+		);
+	}
+
+	/**
 	 * Parses next element in the 'initial' insertion mode.
 	 *
 	 * This internal function performs the 'initial' insertion mode

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1533,24 +1533,27 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * which does not appear in the input HTML text (e.g. a TBODY element
 	 * implied by a TR inside a TABLE).
 	 *
-	 * Unlike the DOM `innerHTML` setter, which operates on a tree, this method
-	 * operates on the HTML text of the document. There are trees which can be
-	 * created through the DOM whose HTML serialization does not reproduce the
-	 * same tree. Content is rejected unless the final document parses with the
-	 * new content fully contained inside the context element and with no
-	 * changes of any kind outside of it.
+	 * The content is interpreted the same way a browser interprets content
+	 * assigned to the `innerHTML` property: it is parsed as an HTML fragment
+	 * in the context of the matched element, and the document is updated with
+	 * the serialization of the parsed result. The text written into the
+	 * document is therefore a normalized form of the given content: syntax
+	 * which parses to nothing is removed (e.g. `</a>` inside an A element, or
+	 * a `<body>` tag, which parsers ignore), unclosed elements are explicitly
+	 * closed, and text and attribute values may be re-encoded.
+	 *
+	 * Unlike the DOM, whose trees need not correspond to any HTML text, the
+	 * HTML Processor's document is HTML text. There are trees which can be
+	 * created through the DOM whose serialization does not reproduce the same
+	 * tree when parsed again in place. Content is rejected unless the updated
+	 * document parses with the new content fully contained inside the context
+	 * element and with no changes of any kind outside of it.
 	 *
 	 * Rejected content leaves the document unmodified and returns `false`:
 	 *
-	 *  - Content which would close the context element or continue outside of it,
-	 *    e.g. setting `</p>outside` inside a P element.
 	 *  - Content whose elements would implicitly close the context element,
 	 *    e.g. setting `<li>` inside an LI element, or `<a>` inside an A element,
 	 *    because nesting these elements cannot be represented in HTML text.
-	 *  - Content which would modify parts of the document following the context
-	 *    element, e.g. setting `<b>unclosed` inside a DIV element which is
-	 *    followed by more content, because the unclosed B element would wrap
-	 *    that following content when the document is parsed again.
 	 *  - Content which the HTML Processor cannot parse, e.g. markup requiring
 	 *    foster-parenting, such as setting `text` directly inside a TABLE element.
 	 *  - Content inside a SELECT element other than OPTION, OPTGROUP, and HR
@@ -1562,7 +1565,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *     $processor = WP_HTML_Processor::create_fragment( '<div>old</div><p>kept</p>' );
 	 *     $processor->next_tag( 'DIV' );
 	 *     true === $processor->set_inner_html( '<p>one<p>two' );
-	 *     $processor->get_updated_html() === '<div><p>one<p>two</div><p>kept</p>';
+	 *     $processor->get_updated_html() === '<div><p>one</p><p>two</p></div><p>kept</p>';
 	 *
 	 *     $processor = WP_HTML_Processor::create_fragment( '<a href="/wp/">WordPress</a>' );
 	 *     $processor->next_tag( 'A' );
@@ -1579,7 +1582,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 7.1.0
 	 *
-	 * @param string $html Raw HTML to replace the contents of the currently-matched element.
+	 * @param string $html HTML for the new content of the currently-matched element.
 	 * @return bool Whether the content was accepted and the document updated.
 	 */
 	public function set_inner_html( string $html ): bool {
@@ -1608,22 +1611,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		/*
-		 * Reject content whose parsing is known to diverge from browsers,
-		 * because reparsing with the HTML Processor cannot detect whether
-		 * such content modifies the document outside of the context element.
-		 *
-		 *  - When an HTML or BODY start tag appears in a document, HTML parsers
-		 *    may adopt its attributes onto the existing HTML or BODY elements,
-		 *    modifying elements outside of the context element. The HTML
-		 *    Processor ignores these tags instead of adopting the attributes.
-		 *
-		 *  - The HTML Processor still parses SELECT content under rules which
-		 *    predate the "customizable select element" changes to HTML. It
-		 *    ignores most tags inside a SELECT element, while up-to-date
-		 *    parsers allow many of them, possibly escaping the SELECT and
-		 *    reopening formatting elements beyond the context element. Only
-		 *    tokens treated identically under both revisions of HTML are
-		 *    allowed inside a SELECT element. See https://core.trac.wordpress.org/ticket/63736.
+		 * The HTML Processor still parses SELECT content under rules which
+		 * predate the "customizable select element" changes to HTML. It
+		 * ignores most tags inside a SELECT element, while up-to-date parsers
+		 * allow many of them. Silently applying the outdated rules would drop
+		 * content that browsers preserve, so only tokens treated identically
+		 * under both revisions of HTML are allowed inside a SELECT element.
+		 * Remove this restriction when SELECT parsing is updated.
+		 * See https://core.trac.wordpress.org/ticket/63736.
 		 */
 		$context_in_select = in_array( 'SELECT', $this->get_breadcrumbs(), true );
 		$select_depth      = $context_in_select ? 1 : 0;
@@ -1654,10 +1649,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				continue;
 			}
 
-			if ( 'HTML' === $scanned_tag || 'BODY' === $scanned_tag ) {
-				return false;
-			}
-
 			if ( 'SELECT' === $scanned_tag ) {
 				// A SELECT element may not appear inside another SELECT element.
 				if ( $select_depth > 0 ) {
@@ -1673,6 +1664,28 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			) {
 				return false;
 			}
+		}
+
+		/*
+		 * Parse the content as an HTML fragment in the context of the matched
+		 * element, the same interpretation the DOM `innerHTML` setter applies.
+		 * The serialization of the parsed fragment, not the given text, is
+		 * what may be written into the document: this removes syntax which
+		 * every HTML parser ignores (e.g. stray tag closers) and explicitly
+		 * closes unclosed elements.
+		 */
+		$fragment = $this->create_fragment_at_current_node( $html );
+		if ( null === $fragment ) {
+			return false;
+		}
+
+		$new_content = '';
+		while ( $fragment->next_token() ) {
+			$new_content .= $fragment->serialize_token();
+		}
+
+		if ( null !== $fragment->get_last_error() ) {
+			return false;
 		}
 
 		// Apply any pending updates so that the document below is final.
@@ -1744,8 +1757,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * closing of the context element onward, the document must produce
 		 * exactly the same structure as it did without the replacement.
 		 */
-		$candidate_document = substr( $document, 0, $inner_start ) . $html . substr( $document, $inner_end );
-		$candidate_end      = $inner_start + strlen( $html );
+		$candidate_document = substr( $document, 0, $inner_start ) . $new_content . substr( $document, $inner_end );
+		$candidate_end      = $inner_start + strlen( $new_content );
 
 		$candidate = $this->create_equivalent_parser( $candidate_document );
 		if (
@@ -1819,7 +1832,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 		}
 
-		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $inner_start, $inner_end - $inner_start, $html );
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement( $inner_start, $inner_end - $inner_start, $new_content );
 		$this->get_updated_html();
 
 		return true;

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-set-inner-html.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-set-inner-html.php
@@ -1,0 +1,443 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor functionality for replacing
+ * the inner content of an element.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 7.1.0
+ */
+
+/**
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
+	/**
+	 * Ensures that inner content is replaced when the new content remains
+	 * fully contained within the context element.
+	 *
+	 * @covers ::set_inner_html
+	 *
+	 * @dataProvider data_content_replaced_within_context_element
+	 *
+	 * @param string $html      Input HTML document.
+	 * @param string $target    Tag name of the element whose content is replaced.
+	 * @param string $new_html  Content passed to `set_inner_html()`.
+	 * @param string $expected  Expected document after the replacement.
+	 */
+	public function test_replaces_inner_html( string $html, string $target, string $new_html, string $expected ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertTrue(
+			$processor->next_tag( $target ),
+			"Could not find {$target} element in test document: check test setup."
+		);
+
+		$this->assertTrue(
+			$processor->set_inner_html( $new_html ),
+			'Should have accepted content which is fully contained within the context element.'
+		);
+
+		$this->assertSame(
+			$expected,
+			$processor->get_updated_html(),
+			'Should have replaced the inner content of the context element and nothing else.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_content_replaced_within_context_element(): array {
+		return array(
+			'Plain text'                    => array( '<div>old content</div>after', 'DIV', 'fresh', '<div>fresh</div>after' ),
+			'Empty content'                 => array( '<div>full of stuff</div>', 'DIV', '', '<div></div>' ),
+			'Element markup'                => array( '<div>a<span>b</span>c</div>', 'DIV', '<p>replaced</p>', '<div><p>replaced</p></div>' ),
+			'Markup with implied closers'   => array( '<div>x</div><p>kept</p>', 'DIV', '<p>one<p>two', '<div><p>one<p>two</div><p>kept</p>' ),
+			'Same element nested'           => array( '<div>x</div>', 'DIV', '<div>nested</div>', '<div><div>nested</div></div>' ),
+			'Identical content'             => array( '<div><em>same</em></div>', 'DIV', '<em>same</em>', '<div><em>same</em></div>' ),
+			'A with phrasing content'       => array( '<a href="/wp/">WordPress</a>', 'A', 'the <em>best</em> CMS', '<a href="/wp/">the <em>best</em> CMS</a>' ),
+			'Implicitly-closed LI'          => array( '<ul><li>one<li>two</ul>', 'LI', 'replaced', '<ul><li>replaced<li>two</ul>' ),
+			'Implicitly-closed P'           => array( '<p>one<p>two', 'P', 'styled <em>text</em>', '<p>styled <em>text</em><p>two' ),
+			'Unclosed element at end'       => array( '<div><p>dangling', 'P', 'replaced', '<div><p>replaced' ),
+			'Comment'                       => array( '<div>x</div>', 'DIV', '<!-- note -->', '<div><!-- note --></div>' ),
+			'TD cell content'               => array( '<table><tbody><tr><td>old</td></tr></tbody></table>', 'TD', '<span>new</span>', '<table><tbody><tr><td><span>new</span></td></tr></tbody></table>' ),
+			'TABLE rows with implied TBODY' => array( '<table><tbody><tr><td>a</td></tr></tbody></table>', 'TABLE', '<tr><td>b</td></tr>', '<table><tr><td>b</td></tr></table>' ),
+			'SELECT options'                => array( '<select><option>a</option></select>', 'SELECT', '<option>x<option>y', '<select><option>x<option>y</select>' ),
+			'SVG foreign content'           => array( '<svg><circle r="1"></circle></svg>', 'SVG', '<rect width="4"/>', '<svg><rect width="4"/></svg>' ),
+			'Closed formatting element'     => array( '<div>x</div><span>after</span>', 'DIV', '<b>bold</b> text', '<div><b>bold</b> text</div><span>after</span>' ),
+			'Closed SELECT within content'  => array( '<div>x</div>', 'DIV', '<select><option>a</select><p>after', '<div><select><option>a</select><p>after</div>' ),
+		);
+	}
+
+	/**
+	 * Ensures that content is rejected and the document unmodified when accepting
+	 * the content would modify the structure outside of the context element.
+	 *
+	 * The HTML Processor has HTML text as input and output. Unlike the DOM,
+	 * some trees cannot be represented in HTML text, e.g. an A element nested
+	 * directly inside another A element. Content whose HTML would escape the
+	 * context element when the document is parsed again must be rejected.
+	 *
+	 * @covers ::set_inner_html
+	 *
+	 * @dataProvider data_content_escaping_context_element
+	 *
+	 * @param string $html     Input HTML document.
+	 * @param string $target   Tag name of the element whose content would be replaced.
+	 * @param string $new_html Content passed to `set_inner_html()`.
+	 */
+	public function test_rejects_content_escaping_context_element( string $html, string $target, string $new_html ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertTrue(
+			$processor->next_tag( $target ),
+			"Could not find {$target} element in test document: check test setup."
+		);
+
+		$this->assertFalse(
+			$processor->set_inner_html( $new_html ),
+			'Should have rejected content which would modify the structure outside of the context element.'
+		);
+
+		$this->assertSame(
+			$html,
+			$processor->get_updated_html(),
+			'Should not have modified the document when rejecting the content.'
+		);
+
+		$this->assertNull(
+			$processor->get_last_error(),
+			'Should not have entered a failed state when rejecting the content.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_content_escaping_context_element(): array {
+		return array(
+			'A inside A'                 => array( '<a href="/wp/">WordPress</a>', 'A', '<a>links cannot nest</a>' ),
+			'Closer for context A'       => array( '<a href="/">x</a>y', 'A', '</a>I closed the container' ),
+			'Closer for context DIV'     => array( '<div>x</div>y', 'DIV', '</div><p>escaped' ),
+			'LI inside LI'               => array( '<ul><li>one</li><li>two</li></ul>', 'LI', '<li>lists collapse' ),
+			'P inside P'                 => array( '<p>one</p>', 'P', '<p>paragraphs close paragraphs</p>' ),
+			'Heading inside heading'     => array( '<h1>title</h1>', 'H1', '<h2>headings close headings</h2>' ),
+			'BUTTON inside BUTTON'       => array( '<button>x</button>', 'BUTTON', '<button>buttons close buttons' ),
+			'FORM inside FORM'           => array( '<form>x</form>', 'FORM', '<form>y</form>' ),
+			'SELECT inside SELECT'       => array( '<select><option>a</option></select>', 'SELECT', '<select><option>b' ),
+			'OPTION inside OPTION'       => array( '<select><option>a</option></select>', 'OPTION', '<option>options close options' ),
+			'Unclosed B before content'  => array( '<div>x</div><span>after</span>', 'DIV', '<b>would embolden what follows' ),
+			'Text directly inside TABLE' => array( '<table><tbody><tr><td>a</td></tr></tbody></table>', 'TABLE', 'text would foster-parent' ),
+			'Closer for foreign context' => array( '<svg><circle r="1"></circle></svg>text', 'SVG', '</svg><b>escaped' ),
+			'BODY start tag'             => array( '<div>x</div>', 'DIV', '<body class="x">y' ),
+			'HTML start tag'             => array( '<div>x</div>', 'DIV', '<html lang="en">y' ),
+			'A inside SELECT'            => array( '<select><option>a</option></select>', 'SELECT', '<a>updated SELECT parsing may move this' ),
+			'DIV inside SELECT'          => array( '<select><option>a</option></select>', 'SELECT', '<div>updated SELECT parsing may move this' ),
+			'A inside OPTION in SELECT'  => array( '<select><option>a</option></select>', 'OPTION', '<a>updated SELECT parsing may move this' ),
+			'SELECT closer in OPTION'    => array( '<select><option>a</option></select>', 'OPTION', '</select>escaped' ),
+			'A in SELECT within content' => array( '<div>x</div>after', 'DIV', '<select><a>link' ),
+		);
+	}
+
+	/**
+	 * Ensures that the safety of content depends on its position in the document.
+	 *
+	 * An unclosed B element is contained inside a DIV at the end of a document,
+	 * but in the middle of a document it would wrap the following content in
+	 * bold text once the document is parsed again.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_containment_depends_on_document_position() {
+		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>' );
+		$processor->next_tag( 'DIV' );
+		$this->assertTrue(
+			$processor->set_inner_html( '<b>unclosed' ),
+			'Should have accepted an unclosed formatting element when no content follows the context element.'
+		);
+		$this->assertSame(
+			'<div><b>unclosed</div>',
+			$processor->get_updated_html(),
+			'Should have replaced the inner content of the context element.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>text after' );
+		$processor->next_tag( 'DIV' );
+		$this->assertFalse(
+			$processor->set_inner_html( '<b>unclosed' ),
+			'Should have rejected an unclosed formatting element which would reopen and wrap the content following the context element.'
+		);
+	}
+
+	/**
+	 * Ensures that elements which cannot contain HTML content reject all content.
+	 *
+	 * @covers ::set_inner_html
+	 *
+	 * @dataProvider data_unsupported_context_elements
+	 *
+	 * @param string $html   Input HTML document.
+	 * @param string $target Tag name of the unsupported context element.
+	 */
+	public function test_rejects_unsupported_context_elements( string $html, string $target ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertTrue(
+			$processor->next_tag( $target ),
+			"Could not find {$target} element in test document: check test setup."
+		);
+
+		$this->assertFalse(
+			$processor->set_inner_html( 'anything' ),
+			"Should have rejected content for unsupported context element {$target}."
+		);
+
+		$this->assertSame(
+			$html,
+			$processor->get_updated_html(),
+			'Should not have modified the document when rejecting the content.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_unsupported_context_elements(): array {
+		return array(
+			'Void IMG'                => array( '<img src="a.png">', 'IMG' ),
+			'Void BR'                 => array( '<br>', 'BR' ),
+			'Void INPUT'              => array( '<input type="text">', 'INPUT' ),
+			'Self-contained SCRIPT'   => array( '<script>let a;</script>', 'SCRIPT' ),
+			'Self-contained STYLE'    => array( '<style>p {}</style>', 'STYLE' ),
+			'Self-contained TEXTAREA' => array( '<textarea>text</textarea>', 'TEXTAREA' ),
+			'Self-contained TITLE'    => array( '<title>text</title>', 'TITLE' ),
+			'Self-contained IFRAME'   => array( '<iframe src="/"></iframe>', 'IFRAME' ),
+			'Self-contained XMP'      => array( '<xmp>text</xmp>', 'XMP' ),
+		);
+	}
+
+	/**
+	 * Ensures that content is rejected when the processor is not paused on
+	 * the opening tag of an element found in the input HTML text.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_rejects_when_not_on_a_tag_opener() {
+		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>' );
+		$this->assertFalse(
+			$processor->set_inner_html( 'new' ),
+			'Should have rejected content before the processor started scanning.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( 'just text' );
+		$processor->next_token();
+		$this->assertSame( '#text', $processor->get_token_type(), 'Should have matched a text node: check test setup.' );
+		$this->assertFalse(
+			$processor->set_inner_html( 'new' ),
+			'Should have rejected content when matched on a text node.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>' );
+		$processor->next_tag(
+			array(
+				'tag_name'    => 'DIV',
+				'tag_closers' => 'visit',
+			)
+		);
+		$processor->next_tag(
+			array(
+				'tag_name'    => 'DIV',
+				'tag_closers' => 'visit',
+			)
+		);
+		$this->assertTrue( $processor->is_tag_closer(), 'Should have matched the DIV closer: check test setup.' );
+		$this->assertFalse(
+			$processor->set_inner_html( 'new' ),
+			'Should have rejected content when matched on a tag closer.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>' );
+		while ( $processor->next_token() ) {
+			continue;
+		}
+		$this->assertFalse(
+			$processor->set_inner_html( 'new' ),
+			'Should have rejected content after the document was fully processed.'
+		);
+	}
+
+	/**
+	 * Ensures that content is rejected on elements which do not appear in the
+	 * input HTML text, because there is no place in the text for the content.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_rejects_virtual_nodes() {
+		$processor = WP_HTML_Processor::create_fragment( '<table><tr><td>x</td></tr></table>' );
+		$this->assertTrue(
+			$processor->next_tag( 'TBODY' ),
+			'Could not find implied TBODY element in test document: check test setup.'
+		);
+
+		$this->assertFalse(
+			$processor->set_inner_html( '<tr><td>y</td></tr>' ),
+			'Should have rejected content on a TBODY element which does not appear in the input HTML text.'
+		);
+	}
+
+	/**
+	 * Ensures that the processor remains paused on the opening tag of the
+	 * context element after a replacement and continues into the new content.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_remains_on_context_element_and_parses_new_content() {
+		$processor = WP_HTML_Processor::create_fragment( '<div>old</div><span>after</span>' );
+		$processor->next_tag( 'DIV' );
+		$this->assertTrue( $processor->set_inner_html( '<p>new' ), 'Should have accepted contained content.' );
+
+		$this->assertSame( 'DIV', $processor->get_tag(), 'Should have remained paused on the context element.' );
+		$this->assertFalse( $processor->is_tag_closer(), 'Should have remained paused on the opening tag.' );
+
+		$this->assertTrue( $processor->next_token(), 'Should have found the newly-set content.' );
+		$this->assertSame( 'P', $processor->get_tag(), 'Should have parsed the new content in place.' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'DIV', 'P' ),
+			$processor->get_breadcrumbs(),
+			'Should have found the new content inside the context element.'
+		);
+
+		$this->assertTrue( $processor->next_tag( 'SPAN' ), 'Should have continued into the content following the context element.' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'SPAN' ),
+			$processor->get_breadcrumbs(),
+			'Should have left the structure after the context element unmodified.'
+		);
+	}
+
+	/**
+	 * Ensures that a processor remains usable after rejecting content.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_remains_usable_after_rejecting_content() {
+		$processor = WP_HTML_Processor::create_fragment( '<a>x</a><p>tail</p>' );
+		$processor->next_tag( 'A' );
+		$this->assertFalse( $processor->set_inner_html( '<a>nested</a>' ), 'Should have rejected an A element inside an A element.' );
+
+		$this->assertSame( 'A', $processor->get_tag(), 'Should have remained paused on the context element.' );
+		$this->assertTrue( $processor->next_tag( 'P' ), 'Should have continued scanning after rejecting content.' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'P' ),
+			$processor->get_breadcrumbs(),
+			'Should have preserved proper structure after rejecting content.'
+		);
+	}
+
+	/**
+	 * Ensures that replacements are rejected when the document following the
+	 * context element contains markup the HTML Processor cannot verify.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_rejects_when_following_content_cannot_be_verified() {
+		$html      = '<div>x</div><table>text-needs-foster-parenting';
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$processor->next_tag( 'DIV' );
+
+		$this->assertFalse(
+			$processor->set_inner_html( 'safe content' ),
+			'Should have rejected content when the following document cannot be verified.'
+		);
+
+		$this->assertNull(
+			$processor->get_last_error(),
+			'Should not have entered a failed state when the verification parse failed.'
+		);
+
+		$this->assertSame( $html, $processor->get_updated_html(), 'Should not have modified the document.' );
+	}
+
+	/**
+	 * Ensures that enqueued attribute updates on the context element are
+	 * preserved when replacing its inner content.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_combines_with_attribute_updates() {
+		$processor = WP_HTML_Processor::create_fragment( '<div>old</div>' );
+		$processor->next_tag( 'DIV' );
+		$processor->set_attribute( 'class', 'updated' );
+
+		$this->assertTrue( $processor->set_inner_html( 'new' ), 'Should have accepted contained content.' );
+		$this->assertSame(
+			'<div class="updated">new</div>',
+			$processor->get_updated_html(),
+			'Should have applied both the attribute update and the content replacement.'
+		);
+	}
+
+	/**
+	 * Ensures that bookmarks into the replaced content are released while
+	 * bookmarks outside of it survive and remain usable.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_releases_bookmarks_into_replaced_content() {
+		$processor = WP_HTML_Processor::create_fragment( '<div><p>inner</p></div><span>after</span>' );
+		$processor->next_tag( 'DIV' );
+		$processor->set_bookmark( 'target' );
+		$processor->next_tag( 'P' );
+		$processor->set_bookmark( 'inside' );
+		$processor->next_tag( 'SPAN' );
+		$processor->set_bookmark( 'outside' );
+		$processor->seek( 'target' );
+
+		$this->assertTrue( $processor->set_inner_html( 'replaced' ), 'Should have accepted contained content.' );
+
+		$this->assertFalse(
+			$processor->has_bookmark( 'inside' ),
+			'Should have released the bookmark pointing into the replaced content.'
+		);
+
+		$this->assertTrue(
+			$processor->has_bookmark( 'outside' ),
+			'Should have preserved the bookmark pointing after the context element.'
+		);
+
+		$this->assertTrue( $processor->seek( 'outside' ), 'Should have sought to the preserved bookmark.' );
+		$this->assertSame( 'SPAN', $processor->get_tag(), 'Should have found the originally-bookmarked element.' );
+
+		$this->assertSame(
+			'<div>replaced</div><span>after</span>',
+			$processor->get_updated_html(),
+			'Should have replaced the inner content of the context element and nothing else.'
+		);
+	}
+
+	/**
+	 * Ensures that inner content may be replaced in full documents.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_replaces_inner_html_in_full_parser() {
+		$processor = WP_HTML_Processor::create_full_parser(
+			'<!DOCTYPE html><html><body><div>x</div><p>y</p></body></html>'
+		);
+		$processor->next_tag( 'DIV' );
+
+		$this->assertTrue( $processor->set_inner_html( '<em>new</em>' ), 'Should have accepted contained content.' );
+		$this->assertSame(
+			'<!DOCTYPE html><html><body><div><em>new</em></div><p>y</p></body></html>',
+			$processor->get_updated_html(),
+			'Should have replaced the inner content of the context element and nothing else.'
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-set-inner-html.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-set-inner-html.php
@@ -16,8 +16,12 @@
  */
 class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
 	/**
-	 * Ensures that inner content is replaced when the new content remains
-	 * fully contained within the context element.
+	 * Ensures that inner content is replaced with the serialization of the
+	 * content parsed as a fragment in the context of the matched element.
+	 *
+	 * The content is interpreted the way the DOM `innerHTML` setter would
+	 * interpret it: syntax which parses to nothing is dropped, unclosed
+	 * elements are closed, and text may be re-encoded.
 	 *
 	 * @covers ::set_inner_html
 	 *
@@ -57,31 +61,44 @@ class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
 			'Plain text'                    => array( '<div>old content</div>after', 'DIV', 'fresh', '<div>fresh</div>after' ),
 			'Empty content'                 => array( '<div>full of stuff</div>', 'DIV', '', '<div></div>' ),
 			'Element markup'                => array( '<div>a<span>b</span>c</div>', 'DIV', '<p>replaced</p>', '<div><p>replaced</p></div>' ),
-			'Markup with implied closers'   => array( '<div>x</div><p>kept</p>', 'DIV', '<p>one<p>two', '<div><p>one<p>two</div><p>kept</p>' ),
 			'Same element nested'           => array( '<div>x</div>', 'DIV', '<div>nested</div>', '<div><div>nested</div></div>' ),
-			'Identical content'             => array( '<div><em>same</em></div>', 'DIV', '<em>same</em>', '<div><em>same</em></div>' ),
+			'A nested in non-A context'     => array( '<div>x</div>', 'DIV', '<a>nested</a>', '<div><a>nested</a></div>' ),
 			'A with phrasing content'       => array( '<a href="/wp/">WordPress</a>', 'A', 'the <em>best</em> CMS', '<a href="/wp/">the <em>best</em> CMS</a>' ),
 			'Implicitly-closed LI'          => array( '<ul><li>one<li>two</ul>', 'LI', 'replaced', '<ul><li>replaced<li>two</ul>' ),
-			'Implicitly-closed P'           => array( '<p>one<p>two', 'P', 'styled <em>text</em>', '<p>styled <em>text</em><p>two' ),
 			'Unclosed element at end'       => array( '<div><p>dangling', 'P', 'replaced', '<div><p>replaced' ),
 			'Comment'                       => array( '<div>x</div>', 'DIV', '<!-- note -->', '<div><!-- note --></div>' ),
 			'TD cell content'               => array( '<table><tbody><tr><td>old</td></tr></tbody></table>', 'TD', '<span>new</span>', '<table><tbody><tr><td><span>new</span></td></tr></tbody></table>' ),
-			'TABLE rows with implied TBODY' => array( '<table><tbody><tr><td>a</td></tr></tbody></table>', 'TABLE', '<tr><td>b</td></tr>', '<table><tr><td>b</td></tr></table>' ),
-			'SELECT options'                => array( '<select><option>a</option></select>', 'SELECT', '<option>x<option>y', '<select><option>x<option>y</select>' ),
-			'SVG foreign content'           => array( '<svg><circle r="1"></circle></svg>', 'SVG', '<rect width="4"/>', '<svg><rect width="4"/></svg>' ),
-			'Closed formatting element'     => array( '<div>x</div><span>after</span>', 'DIV', '<b>bold</b> text', '<div><b>bold</b> text</div><span>after</span>' ),
-			'Closed SELECT within content'  => array( '<div>x</div>', 'DIV', '<select><option>a</select><p>after', '<div><select><option>a</select><p>after</div>' ),
+			'TEMPLATE content'              => array( '<template><p>x</p></template><span>y</span>', 'TEMPLATE', '<em>t</em>', '<template><em>t</em></template><span>y</span>' ),
+
+			// The document receives the serialization of the parsed content, not the given text.
+			'Implied closers made explicit' => array( '<div>x</div><p>kept</p>', 'DIV', '<p>one<p>two', '<div><p>one</p><p>two</p></div><p>kept</p>' ),
+			'Unclosed formatting closed'    => array( '<div>x</div><span>after</span>', 'DIV', '<b>bold', '<div><b>bold</b></div><span>after</span>' ),
+			'Implied TBODY made explicit'   => array( '<table><tbody><tr><td>a</td></tr></tbody></table>', 'TABLE', '<tr><td>b</td></tr>', '<table><tbody><tr><td>b</td></tr></tbody></table>' ),
+			'Implied OPTION closers'        => array( '<select><option>a</option></select>', 'SELECT', '<option>x<option>y', '<select><option>x</option><option>y</option></select>' ),
+			'SVG foreign content'           => array( '<svg><circle r="1"></circle></svg>', 'SVG', '<rect width="4"/>', '<svg><rect width="4" /></svg>' ),
+			'Text is re-encoded'            => array( '<div>x</div>', 'DIV', 'a & b < c', '<div>a &amp; b &lt; c</div>' ),
+
+			// Syntax which fragment parsing ignores is dropped, as the DOM innerHTML setter drops it.
+			'Context closer dropped'        => array( '<div>x</div>y', 'DIV', '</div><p>escaped', '<div><p>escaped</p></div>y' ),
+			'BODY tag dropped'              => array( '<div>x</div>', 'DIV', '<body class="never">y', '<div>y</div>' ),
+			'HTML tag dropped'              => array( '<div>x</div>', 'DIV', '<html lang="en">y', '<div>y</div>' ),
+			'Stray TD dropped'              => array( '<div>x</div>', 'DIV', '<td>y', '<div>y</div>' ),
+			'Nested FORM dropped'           => array( '<form>x</form>', 'FORM', '<form>y</form>', '<form>y</form>' ),
+			'FRAMESET dropped'              => array( '<div>x</div>', 'DIV', '<frameset>', '<div></div>' ),
+			'BODY closer dropped'           => array( '<div>x</div><p>y</p>', 'DIV', 'z</body><!-- c -->', '<div>z<!-- c --></div><p>y</p>' ),
 		);
 	}
 
 	/**
-	 * Ensures that content is rejected and the document unmodified when accepting
-	 * the content would modify the structure outside of the context element.
+	 * Ensures that content is rejected and the document unmodified when the
+	 * parsed content cannot be represented in HTML text at this location
+	 * without modifying the structure outside of the context element.
 	 *
-	 * The HTML Processor has HTML text as input and output. Unlike the DOM,
-	 * some trees cannot be represented in HTML text, e.g. an A element nested
-	 * directly inside another A element. Content whose HTML would escape the
-	 * context element when the document is parsed again must be rejected.
+	 * Fragment parsing accepts this content and produces a tree — a DIV
+	 * assigned `<a>link</a>` via DOM `innerHTML` inside an A element holds a
+	 * nested A element — but no HTML text reproduces that tree in this
+	 * position: parsing the updated document would close the context element
+	 * or restructure the document around it.
 	 *
 	 * @covers ::set_inner_html
 	 *
@@ -123,55 +140,127 @@ class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
 	public static function data_content_escaping_context_element(): array {
 		return array(
 			'A inside A'                 => array( '<a href="/wp/">WordPress</a>', 'A', '<a>links cannot nest</a>' ),
-			'Closer for context A'       => array( '<a href="/">x</a>y', 'A', '</a>I closed the container' ),
-			'Closer for context DIV'     => array( '<div>x</div>y', 'DIV', '</div><p>escaped' ),
 			'LI inside LI'               => array( '<ul><li>one</li><li>two</li></ul>', 'LI', '<li>lists collapse' ),
 			'P inside P'                 => array( '<p>one</p>', 'P', '<p>paragraphs close paragraphs</p>' ),
 			'Heading inside heading'     => array( '<h1>title</h1>', 'H1', '<h2>headings close headings</h2>' ),
 			'BUTTON inside BUTTON'       => array( '<button>x</button>', 'BUTTON', '<button>buttons close buttons' ),
-			'FORM inside FORM'           => array( '<form>x</form>', 'FORM', '<form>y</form>' ),
-			'SELECT inside SELECT'       => array( '<select><option>a</option></select>', 'SELECT', '<select><option>b' ),
 			'OPTION inside OPTION'       => array( '<select><option>a</option></select>', 'OPTION', '<option>options close options' ),
-			'Unclosed B before content'  => array( '<div>x</div><span>after</span>', 'DIV', '<b>would embolden what follows' ),
+			/*
+			 * Rejected today because the HTML Processor cannot parse text inside
+			 * a TABLE. This must remain rejected once foster parenting is
+			 * supported, because the text would be re-parented outside of the
+			 * context element.
+			 */
 			'Text directly inside TABLE' => array( '<table><tbody><tr><td>a</td></tr></tbody></table>', 'TABLE', 'text would foster-parent' ),
-			'Closer for foreign context' => array( '<svg><circle r="1"></circle></svg>text', 'SVG', '</svg><b>escaped' ),
-			'BODY start tag'             => array( '<div>x</div>', 'DIV', '<body class="x">y' ),
-			'HTML start tag'             => array( '<div>x</div>', 'DIV', '<html lang="en">y' ),
-			'A inside SELECT'            => array( '<select><option>a</option></select>', 'SELECT', '<a>updated SELECT parsing may move this' ),
-			'DIV inside SELECT'          => array( '<select><option>a</option></select>', 'SELECT', '<div>updated SELECT parsing may move this' ),
-			'A inside OPTION in SELECT'  => array( '<select><option>a</option></select>', 'OPTION', '<a>updated SELECT parsing may move this' ),
-			'SELECT closer in OPTION'    => array( '<select><option>a</option></select>', 'OPTION', '</select>escaped' ),
-			'A in SELECT within content' => array( '<div>x</div>after', 'DIV', '<select><a>link' ),
+			'Foreign content breakout'   => array( '<svg><circle r="1"></circle></svg>text', 'SVG', '</svg><b>escaped' ),
 		);
 	}
 
 	/**
-	 * Ensures that the safety of content depends on its position in the document.
+	 * Ensures that content is rejected in SELECT contexts except for tokens
+	 * which parse identically under both revisions of SELECT parsing rules.
 	 *
-	 * An unclosed B element is contained inside a DIV at the end of a document,
-	 * but in the middle of a document it would wrap the following content in
-	 * bold text once the document is parsed again.
+	 * CANARY: the HTML Processor parses SELECT content under rules which
+	 * predate the "customizable select element" changes to HTML, ignoring
+	 * tags that up-to-date parsers preserve. Rather than silently applying
+	 * outdated rules, such content is rejected. When SELECT parsing is
+	 * updated these cases should be reevaluated and the restriction removed.
+	 * See https://core.trac.wordpress.org/ticket/63736.
 	 *
 	 * @covers ::set_inner_html
+	 *
+	 * @dataProvider data_content_restricted_in_select_context
+	 *
+	 * @param string $html     Input HTML document.
+	 * @param string $target   Tag name of the element whose content would be replaced.
+	 * @param string $new_html Content passed to `set_inner_html()`.
 	 */
-	public function test_containment_depends_on_document_position() {
-		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>' );
-		$processor->next_tag( 'DIV' );
+	public function test_rejects_restricted_content_in_select_context( string $html, string $target, string $new_html ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
 		$this->assertTrue(
-			$processor->set_inner_html( '<b>unclosed' ),
-			'Should have accepted an unclosed formatting element when no content follows the context element.'
-		);
-		$this->assertSame(
-			'<div><b>unclosed</div>',
-			$processor->get_updated_html(),
-			'Should have replaced the inner content of the context element.'
+			$processor->next_tag( $target ),
+			"Could not find {$target} element in test document: check test setup."
 		);
 
-		$processor = WP_HTML_Processor::create_fragment( '<div>x</div>text after' );
-		$processor->next_tag( 'DIV' );
 		$this->assertFalse(
-			$processor->set_inner_html( '<b>unclosed' ),
-			'Should have rejected an unclosed formatting element which would reopen and wrap the content following the context element.'
+			$processor->set_inner_html( $new_html ),
+			'Should have rejected content whose parsing inside a SELECT element differs across revisions of HTML.'
+		);
+
+		$this->assertSame(
+			$html,
+			$processor->get_updated_html(),
+			'Should not have modified the document when rejecting the content.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_content_restricted_in_select_context(): array {
+		return array(
+			'A inside SELECT'             => array( '<select><option>a</option></select>', 'SELECT', '<a>link' ),
+			'DIV inside SELECT'           => array( '<select><option>a</option></select>', 'SELECT', '<div>block' ),
+			'A inside OPTION in SELECT'   => array( '<select><option>a</option></select>', 'OPTION', '<a>link' ),
+			'SELECT closer inside OPTION' => array( '<select><option>a</option></select>', 'OPTION', '</select>escaped' ),
+			'A in SELECT within content'  => array( '<div>x</div>after', 'DIV', '<select><a>link' ),
+		);
+	}
+
+	/**
+	 * Ensures that content which cannot be parsed as a fragment is rejected
+	 * and leaves the processor and document untouched.
+	 *
+	 * CANARY: these rejections pin current parser limitations, not the
+	 * intended contract. Stray formatting-element closers require adoption
+	 * agency support which the HTML Processor does not implement for the
+	 * "any other end tag" case. Fragment parsing drops these tokens, so when
+	 * support is added these cases should become accepted with the stray
+	 * closer removed from the content.
+	 *
+	 * @covers ::set_inner_html
+	 *
+	 * @dataProvider data_content_currently_unparseable
+	 *
+	 * @param string $html     Input HTML document.
+	 * @param string $target   Tag name of the element whose content would be replaced.
+	 * @param string $new_html Content passed to `set_inner_html()`.
+	 */
+	public function test_rejects_content_it_cannot_parse( string $html, string $target, string $new_html ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$this->assertTrue(
+			$processor->next_tag( $target ),
+			"Could not find {$target} element in test document: check test setup."
+		);
+
+		$this->assertFalse(
+			$processor->set_inner_html( $new_html ),
+			'Should have rejected content which cannot currently be parsed as a fragment.'
+		);
+
+		$this->assertSame(
+			$html,
+			$processor->get_updated_html(),
+			'Should not have modified the document when rejecting the content.'
+		);
+
+		$this->assertNull(
+			$processor->get_last_error(),
+			'Should not have entered a failed state when rejecting the content.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_content_currently_unparseable(): array {
+		return array(
+			'Stray A closer'               => array( '<a href="/">x</a>y', 'A', '</a>I closed the container' ),
+			'Stray B closer in formatting' => array( '<b><div>x</div>y</b>z', 'DIV', 'w</b>v' ),
 		);
 	}
 
@@ -345,6 +434,12 @@ class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
 	 * Ensures that replacements are rejected when the document following the
 	 * context element contains markup the HTML Processor cannot verify.
 	 *
+	 * CANARY: this pins conservative behavior tied to current parser support.
+	 * The content itself is safe; the rejection occurs because the document
+	 * following the context element cannot be reparsed for verification.
+	 * When the HTML Processor learns to parse this document, the replacement
+	 * should be accepted and this test updated.
+	 *
 	 * @covers ::set_inner_html
 	 */
 	public function test_rejects_when_following_content_cannot_be_verified() {
@@ -438,6 +533,29 @@ class Tests_HtmlApi_WpHtmlProcessor_SetInnerHtml extends WP_UnitTestCase {
 			'<!DOCTYPE html><html><body><div><em>new</em></div><p>y</p></body></html>',
 			$processor->get_updated_html(),
 			'Should have replaced the inner content of the context element and nothing else.'
+		);
+	}
+
+	/**
+	 * Ensures that a BODY closer inside content is dropped in a full document,
+	 * where it could otherwise re-target following content to the HTML element.
+	 *
+	 * @covers ::set_inner_html
+	 */
+	public function test_drops_body_closer_in_full_parser() {
+		$processor = WP_HTML_Processor::create_full_parser(
+			'<!DOCTYPE html><html><body><div>x</div><p>y</p></body></html>'
+		);
+		$processor->next_tag( 'DIV' );
+
+		$this->assertTrue(
+			$processor->set_inner_html( 'z</body><!-- c -->' ),
+			'Should have accepted content whose ignored BODY closer is dropped.'
+		);
+		$this->assertSame(
+			'<!DOCTYPE html><html><body><div>z<!-- c --></div><p>y</p></body></html>',
+			$processor->get_updated_html(),
+			'Should have dropped the BODY closer and contained the comment inside the context element.'
 		);
 	}
 }

--- a/tools/html-api-fuzz/set-inner-html-oracle.php
+++ b/tools/html-api-fuzz/set-inner-html-oracle.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Oracle check for WP_HTML_Processor::set_inner_html().
+ *
+ * Verifies the core invariant of set_inner_html(): for every replacement the
+ * method ACCEPTS, parsing the original and the updated documents with
+ * Dom\HTMLDocument (lexbor, browser-grade) must produce identical trees
+ * outside of the context element. Rejections are allowed to be conservative
+ * and are only counted.
+ *
+ * Requires PHP 8.4+ for Dom\HTMLDocument.
+ *
+ * Usage: php tools/html-api-fuzz/set-inner-html-oracle.php
+ *
+ * Exits 0 when no violations are found, 1 on violations, 2 when the
+ * environment cannot run the check.
+ */
+
+error_reporting( E_ALL );
+
+if ( ! class_exists( Dom\HTMLDocument::class ) ) {
+	fwrite( STDERR, "Dom\\HTMLDocument unavailable (requires PHP 8.4+); cannot run oracle check.\n" );
+	exit( 2 );
+}
+
+/*
+ * Minimal WordPress shims so the HTML API sources load standalone.
+ */
+function _doing_it_wrong( $method, $message, $version ) {}
+function __( $text ) {
+	return $text;
+}
+function wp_trigger_error( $method, $message, $level = E_USER_NOTICE ) {}
+function esc_attr( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES );
+}
+function wp_kses_uri_attributes() {
+	return array();
+}
+function wp_scrub_utf8( $text ) {
+	return false !== mb_check_encoding( $text, 'UTF-8' ) && mb_check_encoding( $text, 'UTF-8' )
+		? $text
+		: mb_convert_encoding( $text, 'UTF-8', 'UTF-8' );
+}
+function wp_has_noncharacters( $text ) {
+	return false;
+}
+
+$includes = dirname( __DIR__, 2 ) . '/src/wp-includes';
+require "{$includes}/class-wp-token-map.php";
+foreach ( array(
+	'html5-named-character-references.php',
+	'class-wp-html-attribute-token.php',
+	'class-wp-html-span.php',
+	'class-wp-html-text-replacement.php',
+	'class-wp-html-decoder.php',
+	'class-wp-html-doctype-info.php',
+	'class-wp-html-tag-processor.php',
+	'class-wp-html-unsupported-exception.php',
+	'class-wp-html-token.php',
+	'class-wp-html-stack-event.php',
+	'class-wp-html-open-elements.php',
+	'class-wp-html-active-formatting-elements.php',
+	'class-wp-html-processor-state.php',
+	'class-wp-html-processor.php',
+) as $file ) {
+	require "{$includes}/html-api/{$file}";
+}
+
+/**
+ * Serializes a document with the target element replaced by a marker,
+ * so two documents can be compared "outside of" that element.
+ *
+ * Replacing the whole element (rather than emptying it) also removes
+ * TEMPLATE contents, which the PHP Dom API does not expose for editing.
+ *
+ * @param string $doc Body-fragment HTML containing one element with a `data-t` attribute.
+ * @return string|null Serialization with the target replaced, or null if no target found.
+ */
+function outside_shape( string $doc ): ?string {
+	$dom = Dom\HTMLDocument::createFromString(
+		"<!DOCTYPE html><html><body>{$doc}</body></html>",
+		LIBXML_NOERROR
+	);
+	$target = $dom->querySelector( '[data-t]' );
+	if ( null === $target ) {
+		return null;
+	}
+	$target->parentNode->replaceChild( $dom->createElement( 'x-marker' ), $target );
+	return $dom->saveHtml();
+}
+
+// Context documents. Each must contain exactly one element carrying `data-t`.
+$documents = array(
+	'<div data-t>x</div>',
+	'<div data-t>x</div>after',
+	'<div data-t>a<span>b</span></div><p>tail</p>',
+	'<span data-t>x</span> more <b>text</b>',
+	'<a href="/" data-t>link</a> rest',
+	'<b><a href="/" data-t>link</a> bold</b> plain',
+	'<p data-t>one<p>two',
+	'<p>one<p data-t>two',
+	'<ul><li data-t>one<li>two</ul>',
+	'<ul><li>one<li data-t>two</ul>',
+	'<h1 data-t>title</h1><p>x</p>',
+	'<button data-t>press</button> after',
+	'<form data-t><input name="a"></form><p>x</p>',
+	'<table><tbody><tr><td data-t>cell</td><td>next</td></tr></tbody></table>',
+	'<table data-t><tbody><tr><td>cell</td></tr></tbody></table>rest',
+	'<select data-t><option>a</option></select>text',
+	'<select><option data-t>a</option><option>b</option></select>',
+	'<div><p><b>bold<p data-t>reconstructed</p></div>tail',
+	'<b>outer<div data-t>x</div>more</b>done',
+	'<svg data-t><circle r="1"></circle></svg>text',
+	'<div data-t><p>deep<em>nest</em></div><table><tbody><tr><td>x</td></tr></tbody></table>',
+	'<template data-t><p>x</p></template><span>y</span>',
+	'<div data-t>x',
+	'<p data-t>unclosed paragraph',
+	'<optgroup data-t><option>x</option></optgroup>',
+	'<dl><dt data-t>term<dd>def</dl>',
+	'<div data-t class="a">x</div><!-- comment -->text',
+);
+
+// Content snippets, from benign to hostile.
+$contents = array(
+	'',
+	'plain text',
+	'<p>simple</p>',
+	'<p>one<p>two',
+	'<div>nested</div>',
+	'<a href="#">link</a>',
+	'<a>unclosed link',
+	'<b>unclosed bold',
+	'<b><i>nested unclosed',
+	'<em>closed</em> trailing',
+	'</a>stray a closer',
+	'</div>stray div closer',
+	'</p>stray p closer',
+	'</li>stray li closer',
+	'</b>stray b closer',
+	'</table>stray table closer',
+	'</svg>stray svg closer',
+	'<li>list item',
+	'<td>cell',
+	'<tr><td>row',
+	'<option>opt',
+	'<button>btn</button>',
+	'<form><input></form>',
+	'<form>unclosed form',
+	'<table><tr><td>t</td></tr></table>',
+	'<table>text<td>fostered',
+	'<h2>heading</h2>',
+	'<!-- comment -->',
+	'<!doctype html>',
+	'<![CDATA[not cdata]]>',
+	'<script>let a = "</div>";</script>',
+	'<script>unclosed script',
+	'<style>p { color: red }</style>',
+	'<textarea></div>not markup</textarea>',
+	'<textarea>unclosed textarea',
+	'<pre>' . "\n" . 'newline</pre>',
+	'<svg><rect/></svg>',
+	'<svg><foreignObject><div>x</div></foreignObject></svg>',
+	'<math><mi>x</mi></math>',
+	'<select><option>x</select>',
+	'<p att="unclosed attribute',
+	'<div',
+	'<',
+	'&amp; &lt; &notanentity;',
+	"nulls \x00 inside",
+	'<span>ok</span></span></span>',
+	'<template><p>tpl</p></template>',
+	'<body class="boo">y',
+	'<html lang="x">y',
+	'<head><meta></head>',
+	'text</body>more',
+	'text</html>more',
+	'<b>closed</b><i>closed</i>',
+	'<p style="a>b">attr with gt</p>',
+	'deeply <span><span><span>nested</span></span></span>',
+);
+
+// Randomized phase: combine atoms into content snippets.
+$atoms = array();
+foreach ( array( 'a', 'b', 'i', 'em', 'div', 'p', 'span', 'li', 'ul', 'td', 'tr', 'table', 'tbody', 'select', 'option', 'optgroup', 'form', 'button', 'h1', 'h2', 'svg', 'math', 'template', 'pre', 'code', 'nobr', 'ruby', 'rt', 'dd', 'dt', 'caption', 'colgroup', 'hr', 'br', 'img', 'blockquote', 'article', 'header', 'marquee', 'object', 'output', 'label', 'u', 's', 'small', 'big', 'font', 'strike', 'tt' ) as $t ) {
+	$atoms[] = "<{$t}>";
+	$atoms[] = "</{$t}>";
+}
+$atoms = array_merge(
+	$atoms,
+	array( 'text ', 'more words ', '<!-- c -->', '&amp;', '&notanentity;', '<', '</', '<x', '<!doctype html>', "\n", '<a href="x">', '<b class="y">', '<td rowspan="2">', '<input>', '<template shadowrootmode="open">' )
+);
+
+mt_srand( 42 );
+$random_contents = array();
+for ( $i = 0; $i < 400; $i++ ) {
+	$n     = mt_rand( 1, 6 );
+	$parts = array();
+	for ( $j = 0; $j < $n; $j++ ) {
+		$parts[] = $atoms[ mt_rand( 0, count( $atoms ) - 1 ) ];
+	}
+	$random_contents[] = implode( '', $parts );
+}
+$contents = array_merge( $contents, $random_contents );
+
+$accepted   = 0;
+$rejected   = 0;
+$violations = 0;
+$errors     = 0;
+
+foreach ( $documents as $doc ) {
+	foreach ( $contents as $content ) {
+		$processor = WP_HTML_Processor::create_fragment( $doc );
+		$found     = false;
+		while ( $processor->next_tag() ) {
+			if ( null !== $processor->get_attribute( 'data-t' ) ) {
+				$found = true;
+				break;
+			}
+		}
+		if ( ! $found ) {
+			++$errors;
+			echo "SETUP: could not find target in: {$doc}\n";
+			continue;
+		}
+
+		$result = $processor->set_inner_html( $content );
+
+		if ( ! $result ) {
+			++$rejected;
+			continue;
+		}
+
+		++$accepted;
+		$updated = $processor->get_updated_html();
+
+		// Oracle: outside shape must be identical.
+		$before = outside_shape( $doc );
+		$after  = outside_shape( $updated );
+		if ( null === $before || null === $after ) {
+			++$errors;
+			echo "ORACLE SETUP FAILURE for doc: {$doc} content: {$content}\n";
+			continue;
+		}
+		if ( $before !== $after ) {
+			++$violations;
+			echo 'VIOLATION:' . "\n" .
+				'  doc:      ' . var_export( $doc, true ) . "\n" .
+				'  content:  ' . var_export( $content, true ) . "\n" .
+				'  updated:  ' . var_export( $updated, true ) . "\n" .
+				"  before:   {$before}\n" .
+				"  after:    {$after}\n";
+		}
+
+		// The processor itself must remain healthy through the end of the document.
+		while ( $processor->next_token() ) {
+			continue;
+		}
+		if ( null !== $processor->get_last_error() ) {
+			++$violations;
+			echo "PROCESSOR FAILED after accepting:\n  doc: {$doc}\n  content: {$content}\n  error: {$processor->get_last_error()}\n";
+		}
+	}
+}
+
+$total = $accepted + $rejected;
+echo "\n{$total} cases: {$accepted} accepted, {$rejected} rejected, {$violations} violations, {$errors} setup errors\n";
+exit( ( $violations > 0 || $errors > 0 ) ? 1 : 0 );


### PR DESCRIPTION
Implementation: the method validates by construction rather than by rule lists. It re-parses the current document to locate the inner span and records a signature for every stack event (operation, provenance, node, namespace, position, breadcrumbs) from the context element's close to EOF; then re-parses the spliced candidate, requiring that new content stays strictly inside the context element and that the post-close event stream is identical. Any escape — `<a>` popping the context `A`, `</div>` closing it, unclosed `<b>` re-wrapping later content, fostered table text — shows up as a stream mismatch and rejects with a clean false; the processor and document are untouched. On success it commits through the existing `WP_HTML_Text_Replacement` machinery, purges bookmarks into the replaced span, and stays paused on the opening tag so parsing continues into the new content.

Two divergences re-parsing can't see are rejected by a lexical pre-scan: `<html>`/`<body>` openers  and SELECT contexts. WP still parses selects per the old spec. Content in or introducing a SELECT is limited to OPTION/OPTGROUP/HR/text/comments for now.

Verification: 55 PHPUnit tests (194 assertions) covering A-in-A, LI, `</a>` escape, tables, SVG, templates, bookmarks, seek interaction, and repeated calls; the full html-api group passes (1,547 tests) and PHPCS is clean. Separately, a scratchpad fuzz harness cross-checked every accepted replacement against Dom\HTMLDocument: 12,285 doc×content cases, 4,003 accepted, zero cases where the tree outside the context element changed.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
