### PR TITLE
HTML API: Review locale-dependent ASCII comparisons

### DIFF
--- a/src/wp-includes/class-wp-token-map.php
+++ b/src/wp-includes/class-wp-token-map.php
@@ -452,7 +452,9 @@ class WP_Token_Map {
 			}
 
 			$term    = str_pad( $word, $this->key_length + 1, "\x00", STR_PAD_RIGHT );
-			$word_at = $ignore_case ? stripos( $this->small_words, $term ) : strpos( $this->small_words, $term );
+			$word_at = $ignore_case
+				? strpos( self::ascii_uppercase( $this->small_words ), self::ascii_uppercase( $term ) )
+				: strpos( $this->small_words, $term );
 			if ( false === $word_at ) {
 				return false;
 			}
@@ -461,7 +463,9 @@ class WP_Token_Map {
 		}
 
 		$group_key = substr( $word, 0, $this->key_length );
-		$group_at  = $ignore_case ? stripos( $this->groups, $group_key ) : strpos( $this->groups, $group_key );
+		$group_at  = $ignore_case
+			? strpos( self::ascii_uppercase( $this->groups ), self::ascii_uppercase( $group_key ) )
+			: strpos( $this->groups, $group_key );
 		if ( false === $group_at ) {
 			return false;
 		}
@@ -478,7 +482,12 @@ class WP_Token_Map {
 			$mapping_length = unpack( 'C', $group[ $at++ ] )[1];
 			$mapping_at     = $at;
 
-			if ( $token_length === $length && 0 === substr_compare( $group, $slug, $token_at, $token_length, $ignore_case ) ) {
+			if (
+				$token_length === $length &&
+				( $ignore_case
+					? self::matches_ascii_case_insensitively( $group, $slug, $token_at )
+					: 0 === substr_compare( $group, $slug, $token_at, $token_length ) )
+			) {
 				return true;
 			}
 
@@ -547,7 +556,9 @@ class WP_Token_Map {
 			}
 
 			$group_key = substr( $text, $offset, $this->key_length );
-			$group_at  = $ignore_case ? stripos( $this->groups, $group_key ) : strpos( $this->groups, $group_key );
+			$group_at  = $ignore_case
+				? strpos( self::ascii_uppercase( $this->groups ), self::ascii_uppercase( $group_key ) )
+				: strpos( $this->groups, $group_key );
 			if ( false === $group_at ) {
 				// Perhaps a short word then.
 				return strlen( $this->small_words ) > 0
@@ -565,7 +576,11 @@ class WP_Token_Map {
 				$mapping_length = unpack( 'C', $group[ $at++ ] )[1];
 				$mapping_at     = $at;
 
-				if ( 0 === substr_compare( $text, $token, $offset + $this->key_length, $token_length, $ignore_case ) ) {
+				$token_matches = $ignore_case
+					? self::matches_ascii_case_insensitively( $text, $token, $offset + $this->key_length )
+					: 0 === substr_compare( $text, $token, $offset + $this->key_length, $token_length );
+
+				if ( $token_matches ) {
 					$matched_token_byte_length = $this->key_length + $token_length;
 					return substr( $group, $mapping_at, $mapping_length );
 				}
@@ -597,7 +612,7 @@ class WP_Token_Map {
 		$small_length = strlen( $this->small_words );
 		$search_text  = substr( $text, $offset, $this->key_length );
 		if ( $ignore_case ) {
-			$search_text = strtoupper( $search_text );
+			$search_text = self::ascii_uppercase( $search_text );
 		}
 		$starting_char = $search_text[0];
 
@@ -605,7 +620,7 @@ class WP_Token_Map {
 		while ( $at < $small_length ) {
 			if (
 				$starting_char !== $this->small_words[ $at ] &&
-				( ! $ignore_case || strtoupper( $this->small_words[ $at ] ) !== $starting_char )
+				( ! $ignore_case || self::ascii_uppercase( $this->small_words[ $at ] ) !== $starting_char )
 			) {
 				$at += $this->key_length + 1;
 				continue;
@@ -619,7 +634,7 @@ class WP_Token_Map {
 
 				if (
 					$search_text[ $adjust ] !== $this->small_words[ $at + $adjust ] &&
-					( ! $ignore_case || strtoupper( $this->small_words[ $at + $adjust ] !== $search_text[ $adjust ] ) )
+					( ! $ignore_case || self::ascii_uppercase( $this->small_words[ $at + $adjust ] ) !== $search_text[ $adjust ] )
 				) {
 					$at += $this->key_length + 1;
 					continue 2;
@@ -631,6 +646,76 @@ class WP_Token_Map {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Returns the ASCII uppercase version of a given string.
+	 *
+	 * Only the ASCII lowercase letters a-z are folded onto their uppercase
+	 * counterparts; all other bytes are left unchanged. This differs from
+	 * `strtoupper()`, which before PHP 8.2 folds bytes according to the
+	 * current process locale. Lookup must be locale-independent.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $text Text to fold.
+	 * @return string ASCII-uppercase version of the given text.
+	 */
+	private static function ascii_uppercase( string $text ): string {
+		return strtr( $text, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' );
+	}
+
+	/**
+	 * Indicates if a span of text matches a given string, ignoring ASCII case.
+	 *
+	 * Matching is performed byte-by-byte and folds only the ASCII letters A-Z
+	 * and a-z onto each other, regardless of the process locale. This differs
+	 * from `substr_compare()` with its case-insensitivity flag, which folds
+	 * bytes according to the current process locale and may treat non-ASCII
+	 * bytes as case variants of each other.
+	 *
+	 * The span begins at the given byte offset into the text and runs for the
+	 * byte length of the search string. A span extending past the end of the
+	 * text never matches.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $text   Text possibly containing the search string.
+	 * @param string $search Search string; its byte length determines the span length.
+	 * @param int    $offset Byte offset into the text where the span begins.
+	 * @return bool Whether the span is an ASCII case-insensitive match for the search string.
+	 */
+	private static function matches_ascii_case_insensitively( string $text, string $search, int $offset ): bool {
+		$length = strlen( $search );
+		if ( $offset < 0 || $offset + $length > strlen( $text ) ) {
+			return false;
+		}
+
+		for ( $at = 0; $at < $length; $at++ ) {
+			$text_byte   = $text[ $offset + $at ];
+			$search_byte = $search[ $at ];
+
+			if ( $text_byte === $search_byte ) {
+				continue;
+			}
+
+			$text_ord   = ord( $text_byte );
+			$search_ord = ord( $search_byte );
+
+			// Fold uppercase ASCII letters onto their lowercase counterparts; no other bytes fold.
+			if ( $text_ord >= 0x41 && $text_ord <= 0x5A ) {
+				$text_ord += 0x20;
+			}
+			if ( $search_ord >= 0x41 && $search_ord <= 0x5A ) {
+				$search_ord += 0x20;
+			}
+
+			if ( $text_ord !== $search_ord ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-decoder.php
+++ b/src/wp-includes/html-api/class-wp-html-decoder.php
@@ -11,6 +11,116 @@
  */
 class WP_HTML_Decoder {
 	/**
+	 * Indicates if a span of text matches a given string, ignoring ASCII case.
+	 *
+	 * Matching is performed byte-by-byte and folds only the ASCII uppercase letters
+	 * A-Z onto their lowercase counterparts, regardless of the process locale.
+	 *
+	 * This exists because PHP's built-in case-insensitive comparisons are locale
+	 * sensitive: `substr_compare()` with its case-insensitivity flag and (before
+	 * PHP 8.2) `strcasecmp()`, `strtolower()`, and friends fold bytes according
+	 * to the current process locale, which may treat non-ASCII bytes as case
+	 * variants of each other or of ASCII letters. HTML requires ASCII
+	 * case insensitivity regardless of locale.
+	 *
+	 * The span begins at the given byte offset into the text and runs for the
+	 * byte length of the search string. A span extending past the end of the
+	 * text never matches, even if the available bytes match the search string.
+	 *
+	 * Example:
+	 *
+	 *     true  === WP_HTML_Decoder::matches_ascii_case_insensitively( 'DIV', 'div' );
+	 *     true  === WP_HTML_Decoder::matches_ascii_case_insensitively( '<!doctype html>', 'HTML', 10 );
+	 *     false === WP_HTML_Decoder::matches_ascii_case_insensitively( "\xCC", "\xEC" );
+	 *     false === WP_HTML_Decoder::matches_ascii_case_insensitively( 'DIVERT', 'div', 3 );
+	 *
+	 * @since 7.1.0
+	 *
+	 * @access private
+	 *
+	 * @see https://infra.spec.whatwg.org/#ascii-case-insensitive
+	 *
+	 * @param string $text   Text possibly containing the search string.
+	 * @param string $search Search string; its byte length determines the span length.
+	 * @param int    $offset Optional. Byte offset into the text where the span begins. Default 0.
+	 * @return bool Whether the span is an ASCII case-insensitive match for the search string.
+	 */
+	public static function matches_ascii_case_insensitively( string $text, string $search, int $offset = 0 ): bool {
+		$length = strlen( $search );
+		if ( $offset < 0 || $offset + $length > strlen( $text ) ) {
+			return false;
+		}
+
+		for ( $at = 0; $at < $length; $at++ ) {
+			$text_byte   = $text[ $offset + $at ];
+			$search_byte = $search[ $at ];
+
+			if ( $text_byte === $search_byte ) {
+				continue;
+			}
+
+			$text_ord   = ord( $text_byte );
+			$search_ord = ord( $search_byte );
+
+			// Fold uppercase ASCII letters onto their lowercase counterparts; no other bytes fold.
+			if ( $text_ord >= 0x41 && $text_ord <= 0x5A ) {
+				$text_ord += 0x20;
+			}
+			if ( $search_ord >= 0x41 && $search_ord <= 0x5A ) {
+				$search_ord += 0x20;
+			}
+
+			if ( $text_ord !== $search_ord ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the ASCII lowercase version of a given string.
+	 *
+	 * Only the ASCII uppercase letters A-Z are folded onto their lowercase
+	 * counterparts; all other bytes are left unchanged. This differs from
+	 * `strtolower()`, which before PHP 8.2 folds bytes according to the
+	 * current process locale.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @access private
+	 *
+	 * @see https://infra.spec.whatwg.org/#ascii-lowercase
+	 *
+	 * @param string $text Text to fold.
+	 * @return string ASCII-lowercase version of the given text.
+	 */
+	public static function ascii_lowercase( string $text ): string {
+		return strtr( $text, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz' );
+	}
+
+	/**
+	 * Returns the ASCII uppercase version of a given string.
+	 *
+	 * Only the ASCII lowercase letters a-z are folded onto their uppercase
+	 * counterparts; all other bytes are left unchanged. This differs from
+	 * `strtoupper()`, which before PHP 8.2 folds bytes according to the
+	 * current process locale.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @access private
+	 *
+	 * @see https://infra.spec.whatwg.org/#ascii-uppercase
+	 *
+	 * @param string $text Text to fold.
+	 * @return string ASCII-uppercase version of the given text.
+	 */
+	public static function ascii_uppercase( string $text ): string {
+		return strtr( $text, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' );
+	}
+
+	/**
 	 * Indicates if an attribute value starts with a given raw string value.
 	 *
 	 * Use this method to determine if an attribute value starts with a given string, regardless
@@ -40,7 +150,7 @@ class WP_HTML_Decoder {
 
 		while ( $search_at < $search_length && $haystack_at < $haystack_end ) {
 			$chars_match = $loose_case
-				? strtolower( $haystack[ $haystack_at ] ) === strtolower( $search_text[ $search_at ] )
+				? self::matches_ascii_case_insensitively( $haystack, $search_text[ $search_at ], $haystack_at )
 				: $haystack[ $haystack_at ] === $search_text[ $search_at ];
 
 			$is_introducer = '&' === $haystack[ $haystack_at ];
@@ -61,7 +171,10 @@ class WP_HTML_Decoder {
 			}
 
 			// If there is a character reference, then the decoded value must exactly match what follows in the search string.
-			if ( 0 !== substr_compare( $search_text, $next_chunk, $search_at, strlen( $next_chunk ), $loose_case ) ) {
+			$chunk_matches = $loose_case
+				? self::matches_ascii_case_insensitively( $search_text, $next_chunk, $search_at )
+				: 0 === substr_compare( $search_text, $next_chunk, $search_at, strlen( $next_chunk ) );
+			if ( ! $chunk_matches ) {
 				return false;
 			}
 

--- a/src/wp-includes/html-api/class-wp-html-doctype-info.php
+++ b/src/wp-includes/html-api/class-wp-html-doctype-info.php
@@ -232,8 +232,8 @@ class WP_HTML_Doctype_Info {
 		 * > The system identifier and public identifier strings must be compared...
 		 * > in an ASCII case-insensitive manner.
 		 */
-		$public_identifier = null === $public_identifier ? '' : strtolower( $public_identifier );
-		$system_identifier = null === $system_identifier ? '' : strtolower( $system_identifier );
+		$public_identifier = null === $public_identifier ? '' : WP_HTML_Decoder::ascii_lowercase( $public_identifier );
+		$system_identifier = null === $system_identifier ? '' : WP_HTML_Decoder::ascii_lowercase( $system_identifier );
 
 		/*
 		 * > The public identifier is set to…
@@ -436,7 +436,7 @@ class WP_HTML_Doctype_Info {
 		 */
 		if (
 			$end < 9 ||
-			0 !== substr_compare( $doctype_html, '<!DOCTYPE', 0, 9, true )
+			! WP_HTML_Decoder::matches_ascii_case_insensitively( $doctype_html, '<!DOCTYPE' )
 		) {
 			return null;
 		}
@@ -489,7 +489,7 @@ class WP_HTML_Doctype_Info {
 		}
 
 		$name_length  = strcspn( $doctype_html, " \t\n\f\r", $at, $end - $at );
-		$doctype_name = str_replace( "\0", "\u{FFFD}", strtolower( substr( $doctype_html, $at, $name_length ) ) );
+		$doctype_name = str_replace( "\0", "\u{FFFD}", WP_HTML_Decoder::ascii_lowercase( substr( $doctype_html, $at, $name_length ) ) );
 
 		$at += $name_length;
 		$at += strspn( $doctype_html, " \t\n\f\r", $at, $end - $at );
@@ -514,7 +514,7 @@ class WP_HTML_Doctype_Info {
 		 * > case-insensitive match for the word "PUBLIC", then consume those characters
 		 * > and switch to the after DOCTYPE public keyword state.
 		 */
-		if ( 0 === substr_compare( $doctype_html, 'PUBLIC', $at, 6, true ) ) {
+		if ( WP_HTML_Decoder::matches_ascii_case_insensitively( $doctype_html, 'PUBLIC', $at ) ) {
 			$at += 6;
 			$at += strspn( $doctype_html, " \t\n\f\r", $at, $end - $at );
 			if ( $at >= $end ) {
@@ -528,7 +528,7 @@ class WP_HTML_Doctype_Info {
 		 * > case-insensitive match for the word "SYSTEM", then consume those characters and switch
 		 * > to the after DOCTYPE system keyword state.
 		 */
-		if ( 0 === substr_compare( $doctype_html, 'SYSTEM', $at, 6, true ) ) {
+		if ( WP_HTML_Decoder::matches_ascii_case_insensitively( $doctype_html, 'SYSTEM', $at ) ) {
 			$at += 6;
 			$at += strspn( $doctype_html, " \t\n\f\r", $at, $end - $at );
 			if ( $at >= $end ) {

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -226,7 +226,12 @@ class WP_HTML_Open_Elements {
 		return (
 			$current_node_name === $identity ||
 			( '#doctype' === $identity && 'html' === $current_node_name ) ||
-			( '#tag' === $identity && ctype_upper( $current_node_name ) )
+			/*
+			 * Elements are identified by their uppercase ASCII names. This check
+			 * avoids `ctype_upper()`, whose classification of bytes outside of
+			 * ASCII depends on the process locale.
+			 */
+			( '#tag' === $identity && strlen( $current_node_name ) === strspn( $current_node_name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' ) )
 		);
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -715,7 +715,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		if ( isset( $query['tag_name'] ) ) {
-			$query['tag_name'] = strtoupper( $query['tag_name'] );
+			$query['tag_name'] = WP_HTML_Decoder::ascii_uppercase( $query['tag_name'] );
 		}
 
 		$needs_class = ( isset( $query['class_name'] ) && is_string( $query['class_name'] ) )
@@ -934,13 +934,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		// Start at the last crumb.
 		$crumb = end( $breadcrumbs );
 
-		if ( '*' !== $crumb && $this->get_tag() !== strtoupper( $crumb ) ) {
+		if ( '*' !== $crumb && $this->get_tag() !== WP_HTML_Decoder::ascii_uppercase( $crumb ) ) {
 			return false;
 		}
 
 		for ( $i = count( $this->breadcrumbs ) - 1; $i >= 0; $i-- ) {
 			$node  = $this->breadcrumbs[ $i ];
-			$crumb = strtoupper( current( $breadcrumbs ) );
+			$crumb = WP_HTML_Decoder::ascii_uppercase( current( $breadcrumbs ) );
 
 			if ( '*' !== $crumb && $node !== $crumb ) {
 				return false;
@@ -1413,7 +1413,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		$tag_name       = str_replace( "\x00", "\u{FFFD}", $this->get_tag() );
 		$in_html        = 'html' === $this->get_namespace();
-		$qualified_name = $in_html ? strtolower( $tag_name ) : $this->get_qualified_tag_name();
+		$qualified_name = $in_html ? WP_HTML_Decoder::ascii_lowercase( $tag_name ) : $this->get_qualified_tag_name();
 		$qualified_name = str_replace( "\x00", "\u{FFFD}", $qualified_name );
 
 		if ( $this->is_tag_closer() ) {
@@ -1897,7 +1897,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if (
 					is_string( $http_equiv ) &&
 					is_string( $content ) &&
-					0 === strcasecmp( $http_equiv, 'Content-Type' )
+					'content-type' === WP_HTML_Decoder::ascii_lowercase( $http_equiv )
 				) {
 					$this->bail( 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' );
 				}
@@ -3015,7 +3015,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * > string "hidden", then: set the frameset-ok flag to "not ok".
 				 */
 				$type_attribute = $this->get_attribute( 'type' );
-				if ( ! is_string( $type_attribute ) || 'hidden' !== strtolower( $type_attribute ) ) {
+				if ( ! is_string( $type_attribute ) || 'hidden' !== WP_HTML_Decoder::ascii_lowercase( $type_attribute ) ) {
 					$this->state->frameset_ok = false;
 				}
 
@@ -3539,7 +3539,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 */
 			case '+INPUT':
 				$type_attribute = $this->get_attribute( 'type' );
-				if ( ! is_string( $type_attribute ) || 'hidden' !== strtolower( $type_attribute ) ) {
+				if ( ! is_string( $type_attribute ) || 'hidden' !== WP_HTML_Decoder::ascii_lowercase( $type_attribute ) ) {
 					goto anything_else;
 				}
 				// @todo Indicate a parse error once it's possible.
@@ -5133,7 +5133,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * > of the token, pop elements from the stack of open elements until node has
 			 * > been popped from the stack, and then return.
 			 */
-			if ( 0 === strcasecmp( $node->node_name, $tag_name ) ) {
+			if (
+				strlen( $node->node_name ) === strlen( $tag_name ) &&
+				WP_HTML_Decoder::matches_ascii_case_insensitively( $node->node_name, $tag_name )
+			) {
 				foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
 					$this->state->stack_of_open_elements->pop();
 					if ( $node === $item ) {
@@ -6534,14 +6537,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 
 			$encoding = $this->get_attribute( 'encoding' );
+			if ( ! is_string( $encoding ) ) {
+				return false;
+			}
 
-			return (
-				is_string( $encoding ) &&
-				(
-					0 === strcasecmp( $encoding, 'application/xhtml+xml' ) ||
-					0 === strcasecmp( $encoding, 'text/html' )
-				)
-			);
+			$encoding = WP_HTML_Decoder::ascii_lowercase( $encoding );
+
+			return 'application/xhtml+xml' === $encoding || 'text/html' === $encoding;
 		}
 
 		$this->bail( 'Should not have reached end of HTML Integration Point detection: check HTML API code.' );
@@ -6561,10 +6563,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 */
 	public static function is_special( $tag_name ): bool {
 		if ( is_string( $tag_name ) ) {
-			$tag_name = strtoupper( $tag_name );
+			$tag_name = WP_HTML_Decoder::ascii_uppercase( $tag_name );
 		} else {
 			$tag_name = 'html' === $tag_name->namespace
-				? strtoupper( $tag_name->node_name )
+				? WP_HTML_Decoder::ascii_uppercase( $tag_name->node_name )
 				: "{$tag_name->namespace} {$tag_name->node_name}";
 		}
 
@@ -6681,7 +6683,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether the given tag is an HTML Void Element.
 	 */
 	public static function is_void( $tag_name ): bool {
-		$tag_name = strtoupper( $tag_name );
+		$tag_name = WP_HTML_Decoder::ascii_uppercase( $tag_name );
 
 		return (
 			'AREA' === $tag_name ||
@@ -6738,7 +6740,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > If label is an ASCII case-insensitive match for any of the labels listed in the
 		 * > table below, then return the corresponding encoding; otherwise return failure.
 		 */
-		switch ( strtolower( $label ) ) {
+		switch ( WP_HTML_Decoder::ascii_lowercase( $label ) ) {
 			case 'unicode-1-1-utf-8':
 			case 'unicode11utf8':
 			case 'unicode20utf8':

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1219,7 +1219,7 @@ class WP_HTML_Tag_Processor {
 
 			$name = substr( $class, $at, $length );
 			if ( $is_quirks ) {
-				$name = strtolower( $name );
+				$name = WP_HTML_Decoder::ascii_lowercase( $name );
 			}
 			$at += $length;
 
@@ -1257,7 +1257,9 @@ class WP_HTML_Tag_Processor {
 		foreach ( $this->class_list() as $class_name ) {
 			if (
 				strlen( $class_name ) === $wanted_length &&
-				0 === substr_compare( $class_name, $wanted_class, 0, strlen( $wanted_class ), $case_insensitive )
+				( $case_insensitive
+					? WP_HTML_Decoder::matches_ascii_case_insensitively( $class_name, $wanted_class )
+					: $class_name === $wanted_class )
 			) {
 				return true;
 			}
@@ -1448,10 +1450,7 @@ class WP_HTML_Tag_Processor {
 			 * normalization could not be part of a tag name.
 			 */
 			for ( $i = 0; $i < $tag_length; $i++ ) {
-				$tag_char  = $tag_name[ $i ];
-				$html_char = $html[ $at + $i ];
-
-				if ( $html_char !== $tag_char && strtoupper( $html_char ) !== $tag_char ) {
+				if ( ! WP_HTML_Decoder::matches_ascii_case_insensitively( $html, $tag_name[ $i ], $at + $i ) ) {
 					$at += $i;
 					continue 2;
 				}
@@ -2267,7 +2266,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 * @see https://html.spec.whatwg.org/#attribute-name-state
 		 */
-		$comparable_name = strtolower( str_replace( "\x00", "\u{FFFD}", $attribute_name ) );
+		$comparable_name = WP_HTML_Decoder::ascii_lowercase( str_replace( "\x00", "\u{FFFD}", $attribute_name ) );
 
 		// If an attribute is listed many times, only use the first declaration and ignore the rest.
 		if ( ! isset( $this->attributes[ $comparable_name ] ) ) {
@@ -2446,7 +2445,7 @@ class WP_HTML_Tag_Processor {
 		if ( $is_quirks ) {
 			foreach ( $this->classname_updates as $updated_name => $action ) {
 				if ( self::REMOVE_CLASS === $action ) {
-					$to_remove[] = strtolower( $updated_name );
+					$to_remove[] = WP_HTML_Decoder::ascii_lowercase( $updated_name );
 				}
 			}
 		} else {
@@ -2473,7 +2472,7 @@ class WP_HTML_Tag_Processor {
 			}
 
 			$name                  = substr( $existing_class, $at, $name_length );
-			$comparable_class_name = $is_quirks ? strtolower( $name ) : $name;
+			$comparable_class_name = $is_quirks ? WP_HTML_Decoder::ascii_lowercase( $name ) : $name;
 			$at                   += $name_length;
 
 			// If this class is marked for removal, remove it and move on to the next one.
@@ -2509,7 +2508,7 @@ class WP_HTML_Tag_Processor {
 
 		// Add new classes by appending those which haven't already been seen.
 		foreach ( $this->classname_updates as $name => $operation ) {
-			$comparable_name = $is_quirks ? strtolower( $name ) : $name;
+			$comparable_name = $is_quirks ? WP_HTML_Decoder::ascii_lowercase( $name ) : $name;
 			if ( self::ADD_CLASS === $operation && ! in_array( $comparable_name, $seen, true ) ) {
 				$modified = true;
 
@@ -2809,7 +2808,7 @@ class WP_HTML_Tag_Processor {
 			return null;
 		}
 
-		$comparable = strtolower( $name );
+		$comparable = WP_HTML_Decoder::ascii_lowercase( $name );
 
 		/*
 		 * For every attribute other than `class` it's possible to perform a quick check if
@@ -2912,7 +2911,7 @@ class WP_HTML_Tag_Processor {
 			return null;
 		}
 
-		$comparable = strtolower( $prefix );
+		$comparable = WP_HTML_Decoder::ascii_lowercase( $prefix );
 
 		$matches = array();
 		foreach ( array_keys( $this->attributes ) as $attr_name ) {
@@ -2958,7 +2957,7 @@ class WP_HTML_Tag_Processor {
 		$tag_name = str_replace( "\x00", "\u{FFFD}", substr( $this->html, $this->tag_name_starts_at, $this->tag_name_length ) );
 
 		if ( self::STATE_MATCHED_TAG === $this->parser_state ) {
-			return strtoupper( $tag_name );
+			return WP_HTML_Decoder::ascii_uppercase( $tag_name );
 		}
 
 		if (
@@ -2989,7 +2988,7 @@ class WP_HTML_Tag_Processor {
 			return $tag_name;
 		}
 
-		$lower_tag_name = strtolower( $tag_name );
+		$lower_tag_name = WP_HTML_Decoder::ascii_lowercase( $tag_name );
 		if ( 'math' === $this->get_namespace() ) {
 			return $lower_tag_name;
 		}
@@ -3138,7 +3137,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$namespace  = $this->get_namespace();
-		$lower_name = strtolower( $attribute_name );
+		$lower_name = WP_HTML_Decoder::ascii_lowercase( $attribute_name );
 
 		if ( 'math' === $namespace && 'definitionurl' === $lower_name ) {
 			return 'definitionURL';
@@ -3911,9 +3910,10 @@ class WP_HTML_Tag_Processor {
 				 * HTML structure is rejected here. It’s the responsibility of calling code to
 				 * perform whatever semantic escaping is necessary to avoid problematic strings.
 				 */
+				$comparable_content = WP_HTML_Decoder::ascii_lowercase( $plaintext_content );
 				if (
-					false !== stripos( $plaintext_content, '<script' ) ||
-					false !== stripos( $plaintext_content, '</script' )
+					str_contains( $comparable_content, '<script' ) ||
+					str_contains( $comparable_content, '</script' )
 				) {
 					return false;
 				}
@@ -4038,7 +4038,7 @@ class WP_HTML_Tag_Processor {
 		$type_string = is_string( $type ) ? trim( $type, " \t\f\r\n" ) : "text/{$lang}";
 
 		// All matches are ASCII case-insensitive; eagerly lower-case for comparison.
-		$type_string = strtolower( $type_string );
+		$type_string = WP_HTML_Decoder::ascii_lowercase( $type_string );
 
 		/*
 		 * > If the script block's type string is a JavaScript MIME type essence match, then
@@ -4300,7 +4300,7 @@ class WP_HTML_Tag_Processor {
 			$has_closing_slash = $tag_name_at < $end && '/' === $sourcecode[ $tag_name_at ];
 			$tag_name_at      += $has_closing_slash ? 1 : 0;
 
-			if ( 0 !== substr_compare( $sourcecode, 'script', $tag_name_at, 6, true ) ) {
+			if ( ! WP_HTML_Decoder::matches_ascii_case_insensitively( $sourcecode, 'script', $tag_name_at ) ) {
 				$at = $tag_at + 1;
 				continue;
 			}
@@ -4415,7 +4415,7 @@ class WP_HTML_Tag_Processor {
 		if ( true === $value ) {
 			$updated_attribute = $name;
 		} else {
-			$comparable_name = strtolower( $name );
+			$comparable_name = WP_HTML_Decoder::ascii_lowercase( $name );
 
 			/**
 			 * Escape attribute values appropriately.
@@ -4451,7 +4451,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
 		 */
-		$comparable_name = strtolower( $name );
+		$comparable_name = WP_HTML_Decoder::ascii_lowercase( $name );
 
 		if ( isset( $this->attributes[ $comparable_name ] ) ) {
 			/*
@@ -4527,7 +4527,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
 		 */
-		$name = strtolower( $name );
+		$name = WP_HTML_Decoder::ascii_lowercase( $name );
 
 		/*
 		 * Any calls to update the `class` attribute directly should wipe out any
@@ -4612,7 +4612,7 @@ class WP_HTML_Tag_Processor {
 		foreach ( $this->classname_updates as $updated_name => $action ) {
 			if (
 				strlen( $updated_name ) === $class_name_length &&
-				0 === substr_compare( $updated_name, $class_name, 0, $class_name_length, true )
+				WP_HTML_Decoder::matches_ascii_case_insensitively( $updated_name, $class_name )
 			) {
 				$this->classname_updates[ $updated_name ] = self::ADD_CLASS;
 				return true;
@@ -4654,7 +4654,7 @@ class WP_HTML_Tag_Processor {
 		foreach ( $this->classname_updates as $updated_name => $action ) {
 			if (
 				strlen( $updated_name ) === $class_name_length &&
-				0 === substr_compare( $updated_name, $class_name, 0, $class_name_length, true )
+				WP_HTML_Decoder::matches_ascii_case_insensitively( $updated_name, $class_name )
 			) {
 				$this->classname_updates[ $updated_name ] = self::REMOVE_CLASS;
 				return true;
@@ -4821,7 +4821,7 @@ class WP_HTML_Tag_Processor {
 			$tag_name = $this->get_tag();
 			if (
 				strlen( $this->sought_tag_name ) !== strlen( $tag_name ) ||
-				0 !== substr_compare( $tag_name, $this->sought_tag_name, 0, null, true )
+				! WP_HTML_Decoder::matches_ascii_case_insensitively( $tag_name, $this->sought_tag_name )
 			) {
 				return false;
 			}

--- a/tests/phpunit/tests/html-api/wpHtmlDecoder.php
+++ b/tests/phpunit/tests/html-api/wpHtmlDecoder.php
@@ -389,6 +389,73 @@ class Tests_HtmlApi_WpHtmlDecoder extends WP_UnitTestCase {
 			array( 'http://wordpress.org', 'Http', 'ascii-case-insensitive', true ),
 			array( 'http://wordpress.org', 'https', 'case-sensitive', false ),
 			array( 'http://wordpress.org', 'https', 'ascii-case-insensitive', false ),
+
+			/*
+			 * ASCII case insensitivity must not extend to non-ASCII bytes, no matter
+			 * the process locale. These byte pairs are case variants of each other in
+			 * common single-byte charmaps (0xCC/0xEC are Ì/ì in Latin-1) and serve as
+			 * canaries: they will match if a locale-sensitive comparison sneaks in.
+			 * The same decoded value must produce the same answer whether it appears
+			 * raw or as a character reference ("\xCC\xB8" is U+0338 in UTF-8).
+			 */
+			'Raw non-ASCII byte does not case-fold'      => array( "\xCC\xB8", "\xEC\xB8", 'ascii-case-insensitive', false ),
+			'Encoded non-ASCII byte does not case-fold'  => array( '&#x338;', "\xEC\xB8", 'ascii-case-insensitive', false ),
+			'Encoded non-ASCII matches its exact bytes'  => array( '&#x338;', "\xCC\xB8", 'ascii-case-insensitive', true ),
+			'Encoded non-ASCII exact bytes are sensible' => array( '&#x338;', "\xCC\xB8", 'case-sensitive', true ),
+			'Raw Ä does not loosely match raw ä'         => array( "\xC4", "\xE4", 'ascii-case-insensitive', false ),
+			'Encoded Ä matches its exact UTF-8 bytes'    => array( '&#xC4;', "\xC3\x84", 'ascii-case-insensitive', true ),
+			'Encoded Ä does not loosely match ä bytes'   => array( '&#xC4;', "\xC3\xA4", 'ascii-case-insensitive', false ),
+			'ASCII case folds around encoded spans'      => array( 'J&#x41;VASCRIPT:', 'javascript:', 'ascii-case-insensitive', true ),
+			'Search text ending inside an encoded span'  => array( '&hellip;', "\xE2\x80", 'ascii-case-insensitive', false ),
 		);
+	}
+
+	/**
+	 * Ensures ASCII case-insensitive matching ignores the process locale.
+	 *
+	 * Locale-sensitive case comparisons can treat non-ASCII bytes as case
+	 * variants of each other, e.g. 0xCC/0xEC (Ì/ì in Latin-1). This test
+	 * switches to a locale where the C library folds those bytes and
+	 * asserts that matching remains byte-exact outside of ASCII.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_attribute_starts_with_ignores_process_locale() {
+		$folding_locale = null;
+		foreach ( array( 'de_DE.ISO8859-1', 'de_DE.iso88591', 'de_DE', 'C.UTF-8', 'C.utf8', 'en_US.UTF-8' ) as $locale ) {
+			// Detect a locale whose C-library case folding maps Ä (0xC4) onto ä (0xE4).
+			if ( false !== setlocale( LC_CTYPE, $locale ) && 0 === substr_compare( "\xC4", "\xE4", 0, 1, true ) ) {
+				$folding_locale = $locale;
+				break;
+			}
+		}
+
+		if ( self::$original_lc_ctype ) {
+			setlocale( LC_CTYPE, self::$original_lc_ctype );
+		}
+
+		if ( null === $folding_locale ) {
+			$this->markTestSkipped( 'No locale with non-ASCII case folding is available.' );
+		}
+
+		setlocale( LC_CTYPE, $folding_locale );
+		try {
+			$this->assertFalse(
+				WP_HTML_Decoder::attribute_starts_with( "\xC4hnlich", "\xE4hnlich", 'ascii-case-insensitive' ),
+				'Should not have case-folded a raw non-ASCII byte.'
+			);
+			$this->assertFalse(
+				WP_HTML_Decoder::attribute_starts_with( '&#x338;', "\xEC\xB8", 'ascii-case-insensitive' ),
+				'Should not have case-folded a decoded non-ASCII byte.'
+			);
+			$this->assertTrue(
+				WP_HTML_Decoder::attribute_starts_with( 'J&#x41;VASCRIPT:alert(1)', 'javascript:', 'ascii-case-insensitive' ),
+				'Should have case-folded ASCII letters.'
+			);
+		} finally {
+			if ( self::$original_lc_ctype ) {
+				setlocale( LC_CTYPE, self::$original_lc_ctype );
+			}
+		}
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlDoctypeInfo.php
+++ b/tests/phpunit/tests/html-api/wpHtmlDoctypeInfo.php
@@ -64,31 +64,44 @@ class Tests_HtmlApi_WpHtmlDoctypeInfo extends WP_UnitTestCase {
 	 */
 	public static function data_parseable_raw_doctypes(): array {
 		return array(
-			'Missing doctype name'                      => array( '<!DOCTYPE>', 'quirks' ),
-			'HTML5 doctype'                             => array( '<!DOCTYPE html>', 'no-quirks', 'html' ),
-			'HTML5 doctype no whitespace before name'   => array( '<!DOCTYPEhtml>', 'no-quirks', 'html' ),
-			'XHTML doctype'                             => array( '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">', 'no-quirks', 'html', '-//W3C//DTD HTML 4.01//EN', 'http://www.w3.org/TR/html4/strict.dtd' ),
-			'SVG doctype'                               => array( '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', 'quirks', 'svg', '-//W3C//DTD SVG 1.1//EN', 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' ),
-			'MathML doctype'                            => array( '<!DOCTYPE math PUBLIC "-//W3C//DTD MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/mathml2.dtd">', 'quirks', 'math', '-//W3C//DTD MathML 2.0//EN', 'http://www.w3.org/Math/DTD/mathml2/mathml2.dtd' ),
-			'Doctype with null byte replacement'        => array( "<!DOCTYPE null-\0 PUBLIC '\0' '\0\0'>", 'quirks', "null-\u{FFFD}", "\u{FFFD}", "\u{FFFD}\u{FFFD}" ),
-			'Uppercase doctype'                         => array( '<!DOCTYPE UPPERCASE>', 'quirks', 'uppercase' ),
-			'Lowercase doctype'                         => array( '<!doctype lowercase>', 'quirks', 'lowercase' ),
-			'Doctype with whitespace'                   => array( "<!DOCTYPE\n\thtml\f\rPUBLIC\r\n''\t''>", 'no-quirks', 'html', '', '' ),
-			'Doctype trailing characters'               => array( "<!DOCTYPE html PUBLIC '' '' Anything (except closing angle bracket) is just fine here !!!>", 'no-quirks', 'html', '', '' ),
-			'An ugly no-quirks doctype'                 => array( "<!dOcTyPehtml\tPublIC\"pub-id\"'sysid'>", 'no-quirks', 'html', 'pub-id', 'sysid' ),
-			'Missing public ID'                         => array( '<!DOCTYPE html PUBLIC>', 'quirks', 'html' ),
-			'Missing system ID'                         => array( '<!DOCTYPE html SYSTEM>', 'quirks', 'html' ),
-			'Missing close quote public ID'             => array( "<!DOCTYPE html PUBLIC 'xyz>", 'quirks', 'html', 'xyz' ),
-			'Missing close quote system ID'             => array( "<!DOCTYPE html SYSTEM 'xyz>", 'quirks', 'html', null, 'xyz' ),
-			'Missing close quote system ID with public' => array( "<!DOCTYPE html PUBLIC 'abc' 'xyz>", 'quirks', 'html', 'abc', 'xyz' ),
-			'Bogus characters instead of system/public' => array( '<!DOCTYPE html FOOBAR>', 'quirks', 'html' ),
-			'Bogus characters instead of PUBLIC quote'  => array( "<!DOCTYPE html PUBLIC x ''''>", 'quirks', 'html' ),
-			'Bogus characters instead of SYSTEM quote ' => array( "<!DOCTYPE html SYSTEM x ''>", 'quirks', 'html' ),
-			'Emoji'                                     => array( '<!DOCTYPE 🏴󠁧󠁢󠁥󠁮󠁧󠁿 PUBLIC "🔥" "😈">', 'quirks', "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}", '🔥', '😈' ),
+			'Missing doctype name'                         => array( '<!DOCTYPE>', 'quirks' ),
+			'HTML5 doctype'                                => array( '<!DOCTYPE html>', 'no-quirks', 'html' ),
+			'HTML5 doctype no whitespace before name'      => array( '<!DOCTYPEhtml>', 'no-quirks', 'html' ),
+			'XHTML doctype'                                => array( '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">', 'no-quirks', 'html', '-//W3C//DTD HTML 4.01//EN', 'http://www.w3.org/TR/html4/strict.dtd' ),
+			'SVG doctype'                                  => array( '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">', 'quirks', 'svg', '-//W3C//DTD SVG 1.1//EN', 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' ),
+			'MathML doctype'                               => array( '<!DOCTYPE math PUBLIC "-//W3C//DTD MathML 2.0//EN" "http://www.w3.org/Math/DTD/mathml2/mathml2.dtd">', 'quirks', 'math', '-//W3C//DTD MathML 2.0//EN', 'http://www.w3.org/Math/DTD/mathml2/mathml2.dtd' ),
+			'Doctype with null byte replacement'           => array( "<!DOCTYPE null-\0 PUBLIC '\0' '\0\0'>", 'quirks', "null-\u{FFFD}", "\u{FFFD}", "\u{FFFD}\u{FFFD}" ),
+			'Uppercase doctype'                            => array( '<!DOCTYPE UPPERCASE>', 'quirks', 'uppercase' ),
+			'Lowercase doctype'                            => array( '<!doctype lowercase>', 'quirks', 'lowercase' ),
+			'Doctype with whitespace'                      => array( "<!DOCTYPE\n\thtml\f\rPUBLIC\r\n''\t''>", 'no-quirks', 'html', '', '' ),
+			'Doctype trailing characters'                  => array( "<!DOCTYPE html PUBLIC '' '' Anything (except closing angle bracket) is just fine here !!!>", 'no-quirks', 'html', '', '' ),
+			'An ugly no-quirks doctype'                    => array( "<!dOcTyPehtml\tPublIC\"pub-id\"'sysid'>", 'no-quirks', 'html', 'pub-id', 'sysid' ),
+			'Missing public ID'                            => array( '<!DOCTYPE html PUBLIC>', 'quirks', 'html' ),
+			'Missing system ID'                            => array( '<!DOCTYPE html SYSTEM>', 'quirks', 'html' ),
+			'Missing close quote public ID'                => array( "<!DOCTYPE html PUBLIC 'xyz>", 'quirks', 'html', 'xyz' ),
+			'Missing close quote system ID'                => array( "<!DOCTYPE html SYSTEM 'xyz>", 'quirks', 'html', null, 'xyz' ),
+			'Missing close quote system ID with public'    => array( "<!DOCTYPE html PUBLIC 'abc' 'xyz>", 'quirks', 'html', 'abc', 'xyz' ),
+			'Bogus characters instead of system/public'    => array( '<!DOCTYPE html FOOBAR>', 'quirks', 'html' ),
+			'Bogus characters instead of PUBLIC quote'     => array( "<!DOCTYPE html PUBLIC x ''''>", 'quirks', 'html' ),
+			'Bogus characters instead of SYSTEM quote '    => array( "<!DOCTYPE html SYSTEM x ''>", 'quirks', 'html' ),
+			'Emoji'                                        => array( '<!DOCTYPE 🏴󠁧󠁢󠁥󠁮󠁧󠁿 PUBLIC "🔥" "😈">', 'quirks', "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}", '🔥', '😈' ),
 			'Bogus characters instead of SYSTEM quote after public' => array( "<!DOCTYPE html PUBLIC ''x''>", 'quirks', 'html', '' ),
-			'Special quirks mode if system unset'       => array( '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//">', 'quirks', 'html', '-//W3C//DTD HTML 4.01 Frameset//' ),
-			'Special quirks mode if system empty'       => array( '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//" "">', 'quirks', 'html', '-//W3C//DTD HTML 4.01 Frameset//', '' ),
+			'Special quirks mode if system unset'          => array( '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//">', 'quirks', 'html', '-//W3C//DTD HTML 4.01 Frameset//' ),
+			'Special quirks mode if system empty'          => array( '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//" "">', 'quirks', 'html', '-//W3C//DTD HTML 4.01 Frameset//', '' ),
 			'Special limited-quirks mode if system is non-empty' => array( '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//" "non-empty">', 'limited-quirks', 'html', '-//W3C//DTD HTML 4.01 Frameset//', 'non-empty' ),
+			'Mixed-case system keyword'                    => array( "<!DOCTYPE html sYsTem 'about:legacy-compat'>", 'no-quirks', 'html', null, 'about:legacy-compat' ),
+
+			/*
+			 * Keyword and identifier matching must fold ASCII letters only, regardless
+			 * of the process locale. The following bytes are case pairs of ASCII letters
+			 * in common single-byte charmaps: 0xDD is İ in ISO-8859-9 (lowercase i) and
+			 * 0xC4 is Ä in ISO-8859-1. A locale-sensitive comparison could fold them.
+			 */
+			'Non-ASCII byte does not match PUBLIC keyword' => array( "<!DOCTYPE html PUBL\xDDC 'xyz'>", 'quirks', 'html' ),
+			'Non-ASCII byte does not match SYSTEM keyword' => array( "<!DOCTYPE html SYSTE\xCC 'xyz'>", 'quirks', 'html' ),
+			'Non-ASCII byte in DOCTYPE name is preserved'  => array( "<!DOCTYPE HTML\xC4>", 'quirks', "html\xC4" ),
+			'Quirky public ID matches ASCII-insensitively' => array( '<!DOCTYPE html PUBLIC "-//W3O//DTD W3 HTML STRICT 3.0//EN//">', 'quirks', 'html', '-//W3O//DTD W3 HTML STRICT 3.0//EN//' ),
+			'Quirky public ID with non-ASCII byte does not match' => array( "<!DOCTYPE html PUBLIC \"-//W3O//DTD W3 HTML STR\xDDCT 3.0//EN//\">", 'no-quirks', 'html', "-//W3O//DTD W3 HTML STR\xDDCT 3.0//EN//" ),
 		);
 	}
 
@@ -108,12 +121,14 @@ class Tests_HtmlApi_WpHtmlDoctypeInfo extends WP_UnitTestCase {
 	 */
 	public static function invalid_inputs(): array {
 		return array(
-			'Empty string'                  => array( '' ),
-			'Other HTML'                    => array( '<div>' ),
-			'DOCTYPE after HTML'            => array( 'x<!DOCTYPE>' ),
-			'DOCTYPE before HTML'           => array( '<!DOCTYPE>x' ),
-			'Incomplete DOCTYPE'            => array( '<!DOCTYPE' ),
-			'Pseudo DOCTYPE containing ">"' => array( '<!DOCTYPE html PUBLIC ">">' ),
+			'Empty string'                      => array( '' ),
+			'Other HTML'                        => array( '<div>' ),
+			'DOCTYPE after HTML'                => array( 'x<!DOCTYPE>' ),
+			'DOCTYPE before HTML'               => array( '<!DOCTYPE>x' ),
+			'Incomplete DOCTYPE'                => array( '<!DOCTYPE' ),
+			'Pseudo DOCTYPE containing ">"'     => array( '<!DOCTYPE html PUBLIC ">">' ),
+			// 0xD6 is Ö in ISO-8859-1: it must not fold onto the ASCII letter O.
+			'Non-ASCII byte in DOCTYPE keyword' => array( "<!D\xD6CTYPE html>" ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -901,6 +901,91 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures tag queries and breadcrumbs fold ASCII letters only, regardless of locale.
+	 *
+	 * Tag names may contain non-ASCII bytes, which must match byte-for-byte.
+	 * The byte pair 0xC4/0xE4 (Ä/ä in ISO-8859-1) is a case pair in common
+	 * single-byte charmaps: a locale-sensitive comparison would treat the tag
+	 * names below as ASCII case-insensitive matches for each other.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::next_tag
+	 * @covers ::matches_breadcrumbs
+	 */
+	public function test_tag_queries_fold_ascii_case_only() {
+		$processor = WP_HTML_Processor::create_fragment( "<d\xC4ta>" );
+		$this->assertFalse(
+			$processor->next_tag( array( 'tag_name' => "d\xE4ta" ) ),
+			'Should not have matched a tag name differing in non-ASCII bytes.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( "<d\xC4ta>" );
+		$this->assertTrue(
+			$processor->next_tag( array( 'tag_name' => "D\xC4TA" ) ),
+			'Should have matched the tag name with ASCII letters case-folded.'
+		);
+		$this->assertTrue(
+			$processor->matches_breadcrumbs( array( 'body', "d\xC4ta" ) ),
+			'Should have matched breadcrumbs with ASCII letters case-folded.'
+		);
+		$this->assertFalse(
+			$processor->matches_breadcrumbs( array( 'body', "d\xE4ta" ) ),
+			'Should not have matched breadcrumbs differing in non-ASCII bytes.'
+		);
+	}
+
+	/**
+	 * Ensures foreign-content end tag matching folds ASCII letters only, regardless of locale.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_foreign_content_end_tags_fold_ascii_case_only() {
+		$processor = WP_HTML_Processor::create_fragment( "<svg><f\xC4oo></f\xE4oo><rect>" );
+		$processor->next_tag( 'RECT' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'SVG', "F\xC4OO", 'RECT' ),
+			$processor->get_breadcrumbs(),
+			'Should not have closed a foreign element on an end tag differing in non-ASCII bytes.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( "<svg><f\xC4oo></f\xC4oo><rect>" );
+		$processor->next_tag( 'RECT' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'SVG', 'RECT' ),
+			$processor->get_breadcrumbs(),
+			'Should have closed the foreign element on its exact end tag.'
+		);
+	}
+
+	/**
+	 * Ensures MathML annotation-xml encoding checks fold ASCII letters only, regardless of locale.
+	 *
+	 * The value 'application/xhtml+xml' contains the letter i: under a Turkish
+	 * locale, a locale-sensitive comparison would fail to fold I onto i and
+	 * misdetect the HTML integration point.
+	 *
+	 * @ticket 65372
+	 */
+	public function test_annotation_xml_encoding_folds_ascii_case_only() {
+		$processor = WP_HTML_Processor::create_fragment( '<math><annotation-xml encoding="APPLICATION/XHTML+XML"><p>' );
+		$processor->next_tag( 'P' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'MATH', 'ANNOTATION-XML', 'P' ),
+			$processor->get_breadcrumbs(),
+			'Should have recognized the HTML integration point with ASCII letters case-folded.'
+		);
+
+		$processor = WP_HTML_Processor::create_fragment( "<math><annotation-xml encoding=\"application/xhtml+xm\xCC\"><p>" );
+		$processor->next_tag( 'P' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'P' ),
+			$processor->get_breadcrumbs(),
+			'Should not have recognized an HTML integration point with an encoding differing in non-ASCII bytes.'
+		);
+	}
+
+	/**
 	 * Ensures that the processor correctly adjusts the namespace
 	 * for elements inside HTML integration points.
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -837,6 +837,70 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures quirks-mode class matching folds ASCII letters only, regardless of locale.
+	 *
+	 * The byte pair 0xCC/0xEC (Ì/ì in ISO-8859-1) is a case pair in common single-byte
+	 * charmaps: a locale-sensitive comparison would treat the class names below as
+	 * ASCII case-insensitive matches for each other.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::has_class
+	 */
+	public function test_has_class_quirks_mode_folds_ascii_case_only() {
+		$processor = WP_HTML_Processor::create_full_parser( "<span class='GR\xCCN'>" );
+		$processor->next_tag( 'SPAN' );
+		$this->assertTrue(
+			$processor->has_class( "gr\xCCn" ),
+			'Should have matched the class name with ASCII letters case-folded.'
+		);
+		$this->assertFalse(
+			$processor->has_class( "gr\xECn" ),
+			'Should not have case-folded non-ASCII bytes in class names.'
+		);
+	}
+
+	/**
+	 * Ensures quirks-mode class updates fold ASCII letters only, regardless of locale.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::add_class
+	 * @covers ::remove_class
+	 */
+	public function test_add_class_quirks_mode_folds_ascii_case_only() {
+		$processor = WP_HTML_Processor::create_full_parser( '<span>' );
+		$processor->next_tag( 'SPAN' );
+		$processor->add_class( "GR\xCCN" );
+		$processor->add_class( "gr\xCCn" );
+		$this->assertSame(
+			"<span class=\"GR\xCCN\">",
+			$processor->get_updated_html(),
+			'Should have deduplicated ASCII case variants of the same class name.'
+		);
+
+		$processor = WP_HTML_Processor::create_full_parser( '<span>' );
+		$processor->next_tag( 'SPAN' );
+		$processor->add_class( "GR\xCCN" );
+		$processor->add_class( "gr\xECn" );
+		$this->assertSame(
+			"<span class=\"GR\xCCN gr\xECn\">",
+			$processor->get_updated_html(),
+			'Should have added both class names: non-ASCII bytes are not case variants.'
+		);
+
+		$processor = WP_HTML_Processor::create_full_parser( '<span>' );
+		$processor->next_tag( 'SPAN' );
+		$processor->add_class( "GR\xCCN" );
+		$processor->remove_class( "gr\xECn" );
+		$this->assertSame(
+			"<span class=\"GR\xCCN\">",
+			$processor->get_updated_html(),
+			'Should not have cancelled a pending class addition differing in non-ASCII bytes.'
+		);
+	}
+
+	/**
 	 * Ensures that the processor correctly adjusts the namespace
 	 * for elements inside HTML integration points.
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -3248,6 +3248,54 @@ HTML
 	}
 
 	/**
+	 * Ensures tag-name matching folds ASCII letters only, regardless of locale.
+	 *
+	 * Tag names may contain non-ASCII bytes, which must match byte-for-byte.
+	 * The byte pair 0xCC/0xEC (Ì/ì in ISO-8859-1) is a case pair in common
+	 * single-byte charmaps: a locale-sensitive comparison would treat the tag
+	 * names below as ASCII case-insensitive matches for each other.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::next_tag
+	 */
+	public function test_next_tag_matches_tag_names_with_ascii_case_folding_only() {
+		$processor = new WP_HTML_Tag_Processor( "<d\xCCta>" );
+		$this->assertFalse(
+			$processor->next_tag( array( 'tag_name' => "d\xECta" ) ),
+			'Should not have matched a tag name differing in non-ASCII bytes.'
+		);
+
+		$processor = new WP_HTML_Tag_Processor( "<d\xCCta>" );
+		$this->assertTrue(
+			$processor->next_tag( array( 'tag_name' => "D\xCCTA" ) ),
+			'Should have matched the tag name with ASCII letters case-folded.'
+		);
+	}
+
+	/**
+	 * Ensures RAWTEXT closer scanning folds ASCII letters only, regardless of locale.
+	 *
+	 * The byte 0xFD is ı (LATIN SMALL LETTER DOTLESS I) in ISO-8859-9, whose
+	 * uppercase form is the ASCII letter I: under a Turkish locale a
+	 * locale-sensitive comparison would recognize `</t\xFDtle>` as a TITLE
+	 * tag closer.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::next_tag
+	 */
+	public function test_rawtext_closer_matching_folds_ascii_case_only() {
+		$processor = new WP_HTML_Tag_Processor( "<title>a</t\xFDtle>b</title>" );
+		$this->assertTrue( $processor->next_tag(), 'Should have found the TITLE tag.' );
+		$this->assertSame(
+			"a</t\xFDtle>b",
+			$processor->get_modifiable_text(),
+			'Should not have recognized a tag closer containing a non-ASCII byte in its tag name.'
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return Generator<array>

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -494,6 +494,8 @@ HTML
 			'Non-JS SCRIPT with </script>'            => array( '<script type="text/plain">Replace me</script>', 'Just a </script>' ),
 			'Non-JS SCRIPT with <script attributes>'  => array( '<script language="text">Replace me</script>', '<!-- <script sneaky>after' ),
 			'Non-JS SCRIPT with </script attributes>' => array( '<script language="text">Replace me</script>', 'before</script sneaky>after' ),
+			'Non-JS SCRIPT with </SCRIPT>'            => array( '<script type="text/plain">Replace me</script>', 'Just a </SCRIPT>' ),
+			'Non-JS SCRIPT with <SCRipt>'             => array( '<script type="text/html">Replace me</script>', '<!-- Just a <SCRipt>' ),
 		);
 	}
 
@@ -524,6 +526,13 @@ HTML
 		return array(
 			'Simple update'                         => array( '<script></script>', '{}', '<script>{}</script>' ),
 			'Needs no replacement'                  => array( '<script></script>', '<!--<scriptish>', '<script><!--<scriptish></script>' ),
+			/*
+			 * The byte 0xDD is İ (LATIN CAPITAL LETTER I WITH DOT ABOVE) in ISO-8859-9,
+			 * whose lowercase form is the ASCII letter i: under a Turkish locale a
+			 * locale-sensitive comparison would recognize "scr\xDDpt" as an ASCII
+			 * case-insensitive match for "script" and needlessly escape it.
+			 */
+			'Not script: non-ASCII byte in name'    => array( '<script></script>', "1</scr\xDDpt>/", "<script>1</scr\xDDpt>/</script>" ),
 			'var script;1<script>0'                 => array( '<script></script>', 'var script;1<script>0', '<script>var script;1<\u0073cript>0</script>' ),
 			'1</script>/'                           => array( '<script></script>', '1</script>/', '<script>1</\u0073cript>/</script>' ),
 			'var SCRIPT;1<SCRIPT>0'                 => array( '<script></script>', 'var SCRIPT;1<SCRIPT>0', '<script>var SCRIPT;1<\u0053CRIPT>0</script>' ),

--- a/tests/phpunit/tests/wp-token-map/wpTokenMap.php
+++ b/tests/phpunit/tests/wp-token-map/wpTokenMap.php
@@ -382,6 +382,87 @@ class Tests_WpTokenMap extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures ASCII case-insensitive lookup folds ASCII letters only, regardless of locale.
+	 *
+	 * The byte pair 0xCC/0xEC (Ì/ì in ISO-8859-1) is a case pair in common single-byte
+	 * charmaps: a locale-sensitive comparison would treat the words below as ASCII
+	 * case-insensitive matches for each other.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::contains
+	 * @covers ::read_token
+	 */
+	public function test_ascii_case_insensitive_lookup_folds_ascii_case_only() {
+		// Words longer than the group key length are stored in word groups.
+		$map = WP_Token_Map::from_array( array( "ab\xCC" => 'replacement' ) );
+
+		$this->assertFalse(
+			$map->contains( "ab\xEC", 'ascii-case-insensitive' ),
+			'Should not have found a word differing in non-ASCII bytes.'
+		);
+		$this->assertNull(
+			$map->read_token( "ab\xEC", 0, $token_length, 'ascii-case-insensitive' ),
+			'Should not have read a token differing in non-ASCII bytes.'
+		);
+		$this->assertTrue(
+			$map->contains( "AB\xCC", 'ascii-case-insensitive' ),
+			'Should have found the word with ASCII letters case-folded.'
+		);
+		$this->assertSame(
+			'replacement',
+			$map->read_token( "AB\xCC", 0, $token_length, 'ascii-case-insensitive' ),
+			'Should have read the token with ASCII letters case-folded.'
+		);
+
+		// Words not longer than the group key length are stored as small words.
+		$small_map = WP_Token_Map::from_array( array( "k\xCC" => 'replacement' ) );
+
+		$this->assertFalse(
+			$small_map->contains( "k\xEC", 'ascii-case-insensitive' ),
+			'Should not have found a small word differing in non-ASCII bytes.'
+		);
+		$this->assertNull(
+			$small_map->read_token( "k\xEC", 0, $token_length, 'ascii-case-insensitive' ),
+			'Should not have read a small-word token differing in non-ASCII bytes.'
+		);
+		$this->assertTrue(
+			$small_map->contains( "K\xCC", 'ascii-case-insensitive' ),
+			'Should have found the small word with ASCII letters case-folded.'
+		);
+		$this->assertSame(
+			'replacement',
+			$small_map->read_token( "K\xCC", 0, $token_length, 'ascii-case-insensitive' ),
+			'Should have read the small-word token with ASCII letters case-folded.'
+		);
+	}
+
+	/**
+	 * Ensures that contains() and read_token() agree on ASCII case-insensitive lookups.
+	 *
+	 * Previously, read_token() failed to fold ASCII case beyond the first byte of
+	 * small words, disagreeing with contains() for the same word and map.
+	 *
+	 * @ticket 65372
+	 *
+	 * @covers ::contains
+	 * @covers ::read_token
+	 */
+	public function test_reads_small_word_tokens_ascii_case_insensitively() {
+		$map = WP_Token_Map::from_array( array( 'ab' => 'replacement' ) );
+
+		$this->assertTrue(
+			$map->contains( 'AB', 'ascii-case-insensitive' ),
+			'Should have found the word with ASCII letters case-folded.'
+		);
+		$this->assertSame(
+			'replacement',
+			$map->read_token( 'AB', 0, $token_length, 'ascii-case-insensitive' ),
+			'Should have read the token with ASCII letters case-folded.'
+		);
+	}
+
+	/**
 	 * Returns a static copy of the Token Map for HTML5.
 	 * This is a test performance optimization.
 	 *


### PR DESCRIPTION
Makes ASCII case-insensitive matching locale-independent across the HTML API and `WP_Token_Map`.

Trac ticket: https://core.trac.wordpress.org/ticket/65372

## Problem

Every case-insensitive comparison in the HTML API routed through locale-sensitive PHP functions, in two classes:

- `substr_compare()` with its case-insensitivity flag folds bytes via the C library's `tolower()` under the current process locale **on every PHP version, including current master** — the [PHP 8.2 locale-independent case RFC](https://wiki.php.net/rfc/strtolower-ascii) did not touch it.
- `strtolower()`, `strtoupper()`, `strcasecmp()`, and `stripos()` are locale-dependent **before PHP 8.2** (core supports 7.4+), and `ctype_upper()` is locale-dependent on every version.

Any plugin can change the process locale via `setlocale()`, and some platform defaults already fold non-ASCII bytes. Reproduced on PHP 8.5.8 under macOS' default `C.UTF-8` locale with no `setlocale()` call:

```php
substr_compare( "\xEC\xB8", "\xCC\xB8", 0, 2, true ); // 0 — "matches"

// U+0338 is "\xCC\xB8" in UTF-8. Same decoded value, opposite answers:
WP_HTML_Decoder::attribute_starts_with( '&#x0338;',  "\xEC\xB8", 'ascii-case-insensitive' ); // true  (wrong)
WP_HTML_Decoder::attribute_starts_with( "\xCC\xB8", "\xEC\xB8", 'ascii-case-insensitive' ); // false (correct)
```

Consequences:

1. Non-ASCII bytes spuriously match as case variants of each other: tag names, quirks-mode class names, attribute prefixes, DOCTYPE identifiers, and token-map words differing only in non-ASCII bytes are treated as the same name.
2. Under locales which fold across the ASCII boundary (e.g. Turkish dotless-i on glibc), pure-ASCII needles fail to match: `PUBLIC` does not match `public` in a DOCTYPE, `</SCRIPT>` is not escaped when writing JavaScript content into a `<script>` element, and `application/xhtml+xml` is not recognized as an HTML integration point encoding.
3. The same value gives different answers raw vs. encoded, and behavior varies across PHP versions and process locales.

Found via differential fuzzing of `WP_HTML_Decoder::attribute_starts_with()` against a `decode_attribute()` + `str_starts_with()` oracle; the audit then covered every case-fold site in `src/wp-includes/html-api/` plus `WP_Token_Map`.

## Changes

One commit per class, tests first:

1. **`WP_HTML_Decoder`** — adds locale-independent primitives (`matches_ascii_case_insensitively()`, `ascii_lowercase()`, `ascii_uppercase()`; `@since 7.1.0`, `@access private`) and uses them for both comparison paths of `attribute_starts_with()`, so the plain-character and character-reference paths can no longer diverge.
2. **`WP_HTML_Tag_Processor`** — migrates all 21 sites: sought tag names, quirks-mode `class_list`/`has_class`/`add_class`/`remove_class`, attribute-name normalization, `get_tag()`, RAWTEXT closer scanning, script type detection, and script-content escaping plus its rejection guard.
3. **`WP_HTML_Doctype_Info`** — `<!DOCTYPE`/`PUBLIC`/`SYSTEM` keyword matching and name/identifier folding for quirks-mode detection. Adds a `WP_HTML_Decoder` dependency, matching the Tag Processor's existing one.
4. **`WP_HTML_Processor` + `WP_HTML_Open_Elements`** — tag queries, breadcrumbs, foreign-content end tags, annotation-xml integration-point encodings, meta `Content-Type`, `hidden` input type, encoding labels, `is_special()`/`is_void()`, and `ctype_upper()` → `strspn()` in `current_node_is()`.
5. **`WP_Token_Map`** — the same bug class in its documented `ascii-case-insensitive` mode (`stripos`, `substr_compare`, `strtoupper`). Kept dependency-free with private copies of the helpers. This also fixes a pre-existing misplaced parenthesis, `strtoupper( $a !== $b )`, which uppercased a boolean: ignore-case lookups of small words never folded case beyond the first byte, so `read_token( 'AB', 0, $l, 'ascii-case-insensitive' )` failed to find `'ab'` even though `contains( 'AB', 'ascii-case-insensitive' )` reported it present — inconsistent on every PHP version and locale.

The fold helpers are `strtr()`-based (C-level, locale-free, identical to `strtolower()`/`strtoupper()` output on PHP 8.2+ under the C locale); the comparison helper is a zero-allocation byte loop with the same semantics as the `substr_compare()` calls it replaces, including needle-past-end-of-haystack behavior.

## Testing notes

- **Red-first locally** (macOS, PHP 8.5.8, default `C.UTF-8`): decoder character-reference rows, `next_tag()` non-ASCII tag names, quirks-mode `has_class` and `add_class`/`remove_class` dedup, and both `WP_Token_Map` tests all failed before the fix.
- **Canary pins**: the DOCTYPE, script-escaping, `strcasecmp`, and `strtolower`/`strtoupper` failure modes require pre-8.2 PHP or a glibc Turkish locale, neither reachable on the development machine (macOS' `tr_TR` charmap does not implement the dotless-i fold). Those tests are born green but pin the contract with byte pairs chosen to fail loudly if a locale-sensitive comparison ever returns (`0xCC/0xEC`, `0xC4/0xE4` = Ì/ì, Ä/ä in ISO-8859-1; `0xDD` = İ in ISO-8859-9).
- A dedicated decoder test probes for a locale whose `tolower()` folds `0xC4` onto `0xE4`, runs the assertions under it, and restores the locale in `finally` (skips where no such locale exists).
- Existing tests already covered many fold-direction behaviors (`</ScRiPt>` escaping, mixed-case `PublIC`, both `Content-Type` spellings), so providers were extended rather than duplicated.
- Suites run clean: `html-api` + `html-api-token-map` (6037 tests), `kses`, `interactivity-api`; PHPCS clean on all changed files.

## Scope

This covers `src/wp-includes/html-api/` and `WP_Token_Map` (the HTML API's companion class, whose API documents the same `'ascii-case-insensitive'` contract). Locale-sensitive case folding elsewhere in core (kses, shortcodes, …) is a wider, separate question.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: The original decoder bug was found during an AI-assisted differential-fuzzing review. The audit, tests, implementation, and commit messages in this PR were authored by Claude Code working from a written handoff and task specification; directed and reviewed by @sirreal.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
